### PR TITLE
Implementation of Prefilter, changed centrality, PF and Eta study

### DIFF
--- a/efficiency/generateEfficiencies.sh
+++ b/efficiency/generateEfficiencies.sh
@@ -51,10 +51,10 @@ runDelphes() {
 }
 
 
-NJOBS=60        # number of max parallel runs                   50
-NRUNS=100        # number of runs                               100
+NJOBS=10        # number of max parallel runs                   50
+NRUNS=10        # number of runs                               100
 
-NEVENTS=100    # number of events in a run                       1000
+NEVENTS=10    # number of events in a run                       1000
 NEVENTSCC=1000  # number of events in the charm sample
 NEVENTSBB=1000  # number of events in the beauty sample
 
@@ -63,30 +63,34 @@ SYSTEM="PbPb"         # collisionSystem
 # SCENARIO="default"     # detector setup
 SCENARIO="geometry_v1"     # detector setup
 # BFIELD=2       # magnetic field  [kG]
-BFIELD=20       # magnetic field  [kG]
+BFIELD=5       # magnetic field  [kG]
 
-# RADIUS=10
 RADIUS=100
 
-SIGMAT=0.020      # time resolution [ns]
-ITOFSIGMAT=0.050      # time resolution [ns]
-SIGMA0=0.200      # vertex time spread [ns]
-# BARRELRAD=19.    # barrel radius      [cm] (right now equal to TOF)
-# BARRELLEN=38.    # barrel half length [cm] (right now equal to TOF)
+
+# BARRELRAD=20.    # barrel radius      [cm] (right now equal to TOF)
+# BARRELLEN=40.    # barrel half length [cm] (right now equal to TOF)
 BARRELRAD=100.    # barrel radius      [cm] (right now equal to TOF)
-BARRELLEN=200.    # barrel half length [cm] (right now equal to TOF)
-BARRELETA=1.443   # barrel max pseudorapidity
+BARRELLEN=280.    # barrel half length [cm] (right now equal to TOF)
+# BARRELETA=1.443   # barrel max pseudorapidity
+BARRELETA=4.0   # barrel max pseudorapidity
 TAILLX=1.0        # tail on left    [q]
 TAILRX=1.3        # tail on right   [q]
-ITOFRAD=19.       # TOF radius      [cm]
-ITOFLEN=38.       # TOF half length [cm]
+# set inner TOF parameters
+# TOFRAD=20.       # TOF radius      [cm]
+# TOFLEN=56.       # TOF half length [cm]
+# SIGMAT=0.050  # time resolution [ns]
+# # set outer TOF parameters
 TOFRAD=100.       # TOF radius      [cm]
-TOFLEN=200.       # TOF half length [cm]
+TOFLEN=280.       # TOF half length [cm]
+SIGMAT=0.020      # time resolution [ns]
+SIGMA0=0.200      # vertex time spread [ns]
+# set RICH parameters
 RICHRAD=100.      # RICH radius      [cm]
-RICHLEN=200.      # RICH half length [cm]
+RICHLEN=280.      # RICH half length [cm]
 
 ### calculate max eta from geometry
-BARRELETA=`awk -v a=$TOFRAD -v b=$TOFLEN 'BEGIN {th=atan2(a,b)*0.5; sth=sin(th); cth=cos(th); print -log(sth/cth)}'`
+# BARRELETA=`awk -v a=$TOFRAD -v b=$TOFLEN 'BEGIN {th=atan2(a,b)*0.5; sth=sin(th); cth=cos(th); print -log(sth/cth)}'`
 
 #how many events are generated
 echo " --- generating with scenario $SCENARIO setup"
@@ -158,11 +162,11 @@ sed -i -e "s/double Bz .*$/double Bz = ${BFIELD};/" anaEEstudy.cxx
 ### set (i)TOF radius
 sed -i -e "s/set barrel_Radius .*$/set barrel_Radius ${BARRELRAD}e\-2/" propagate.tcl
 sed -i -e "s/double tof_radius = .*$/double tof_radius = ${TOFRAD}\;/" anaEEstudy.cxx
-sed -i -e "s/double inner_tof_radius = .*$/double inner_tof_radius = ${TOFRAD}\;/" anaEEstudy.cxx
+# sed -i -e "s/double inner_tof_radius = .*$/double inner_tof_radius = ${TOFRAD}\;/" anaEEstudy.cxx
 ### set (i)TOF length
 sed -i -e "s/set barrel_HalfLength .*$/set barrel_HalfLength ${BARRELLEN}e\-2/" propagate.tcl
 sed -i -e "s/double tof_length = .*$/double tof_length = ${TOFLEN}\;/" anaEEstudy.cxx
-sed -i -e "s/double inner_tof_length = .*$/double inner_tof_length = ${TOFLEN}\;/" anaEEstudy.cxx
+# sed -i -e "s/double inner_tof_length = .*$/double inner_tof_length = ${TOFLEN}\;/" anaEEstudy.cxx
 ### set TOF acceptance
 sed -i -e "s/set barrel_Acceptance .*$/set barrel_Acceptance \{ 0.0 + 1.0 * fabs(eta) < ${BARRELETA} \}/" propagate.tcl
 ### set TOF time resolution and tails
@@ -171,8 +175,8 @@ sed -i -e "s/set barrel_TailRight .*$/set barrel_TailRight ${TAILRX}/" propagate
 sed -i -e "s/set barrel_TailLeft  .*$/set barrel_TailLeft ${TAILLX}/" propagate.tcl
 sed -i -e "s/double tof_sigmat = .*$/double tof_sigmat = ${SIGMAT}\;/" anaEEstudy.cxx
 sed -i -e "s/double tof_sigma0 = .*$/double tof_sigma0 = ${SIGMA0}\;/" anaEEstudy.cxx
-sed -i -e "s/double inner_tof_sigmat = .*$/double inner_tof_sigmat = ${SIGMAT}\;/" anaEEstudy.cxx
-sed -i -e "s/double inner_tof_sigma0 = .*$/double inner_tof_sigma0 = ${SIGMA0}\;/" anaEEstudy.cxx
+# sed -i -e "s/double inner_tof_sigmat = .*$/double inner_tof_sigmat = ${SIGMAT}\;/" anaEEstudy.cxx
+# sed -i -e "s/double inner_tof_sigma0 = .*$/double inner_tof_sigma0 = ${SIGMA0}\;/" anaEEstudy.cxx
 ### set RICH radius
 sed -i -e "s/double rich_radius = .*$/double rich_radius = ${RICHRAD}\;/" anaEEstudy.cxx
 ### set RICH length
@@ -229,9 +233,9 @@ for I in $(seq 1 $NRUNS); do
     touch .running.$I
 
     runDelphes $I $NEVENTS $NEVENTSCC $NEVENTSBB $SYSTEM &&
-    (#rm -rf delphes.$I.root &&
+    (rm -rf delphes.$I.root &&
      rm -rf .running.$I && echo " --- run $I completed") ||
-    (#rm -rf delphes.$I.root &&
+    (rm -rf delphes.$I.root &&
      rm -rf .running.$I && echo " --- run $I crashed") &
 
 done
@@ -239,9 +243,9 @@ done
 
 wait
 
-hadd delphes.$(expr $NEVENTS \* $NRUNS).root delphes.*.root
-mv delphes.$(expr $NEVENTS \* $NRUNS).root ./data/delphes_files/
-rm -rf delphes.*.root
+# hadd delphes.$(expr $NEVENTS \* $NRUNS).root delphes.*.root
+# mv delphes.$(expr $NEVENTS \* $NRUNS).root ./data/delphes_files/
+# rm -rf delphes.*.root
 
 echo " Finished running Delphes "
 ### merge runs when all done

--- a/efficiency/macros/anaEEstudy.cxx
+++ b/efficiency/macros/anaEEstudy.cxx
@@ -21,9 +21,9 @@ using namespace std;
 
 
 
-bool bSmear    = true;
-bool bUseiTOF   = false;
-bool bPlotPIDhists = false;
+bool bSmear        = true;
+bool bUseiTOF      = false;
+
 
 double Bz = 5;            // in kG,  becomes overwritten by the generateEfficiencies.sh skript
 double eMass = 0.000511;
@@ -36,27 +36,35 @@ Double_t pt_binning[]  = {0.0,0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09,0.1,0
 // Double_t eta_binning[]  = {-5.0,-4.9,-4.8,-4.7,-4.6,-4.5,-4.4,-4.3,-4.2,-4.1,-4.0,-3.9,-3.8,-3.7,-3.6,-3.5,-3.4,-3.3,-3.2,-3.1,-3.0,-2.9,-2.8,-2.7,-2.6,-2.5,-2.4,-2.3,-2.2,-2.1,-2.0,-1.9,-1.8,-1.7,-1.6,-1.5,-1.4,-1.3,-1.2,-1.1,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8,2.9,3.0,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8,3.9,4.0,4.1,4.2,4.3,4.4,4.5,4.6,4.7,4.8,4.9,5.0};
 Int_t nEtaBins = 100;    Double_t maxEta = 5.;
 Int_t nPhiBins = 180;    Double_t maxPhi = 2*TMath::Pi();
+
+// const Int_t n_ptee_bin_c = 520;
+// Double_t ptee_bin_c[n_ptee_bin_c+1] = {};
+// Double_t mee_bin_c[2];
+// Int_t n_mee_bin_c = 1;
+// Double_t dca_bin_c[2];
+// int n_dca_bin_c = 1;
+
 // ptee
 // const Int_t n_ptee_bin_c = 202;
-const Int_t n_ptee_bin_c = 214;
+const Int_t n_ptee_bin_c = 105;
 Double_t ptee_bin_c[n_ptee_bin_c+1] = {};
 // mee
-Double_t mee_bin_c[401];
-Int_t n_mee_bin_c = 400;
+Double_t mee_bin_c[121];
+Int_t n_mee_bin_c = 120;
 // DCA
-Double_t dca_bin_c[201];
-int n_dca_bin_c = 200;
+Double_t dca_bin_c[101];
+int n_dca_bin_c = 100;
 
 
 // outer TOF (100 cm)
 double tof_radius = 100.; // [cm]
-double tof_length = 200.; // [cm]
+double tof_length = 280.; // [cm]
 double tof_sigmat = 0.02; // [ns]
 double tof_sigma0 = 0.20; // [ns]
 
 // inner TOF (19 cm)
-double inner_tof_radius = 19.;  // [cm]
-double inner_tof_length = 38.;  // [cm]
+double inner_tof_radius = 20.;  // [cm]
+double inner_tof_length = 56.;  // [cm]
 double inner_tof_sigmat = 0.05; // [ns]
 double inner_tof_sigma0 = 0.20; // [ns]
 
@@ -71,7 +79,7 @@ double nSigmaRICHEle_forTOFPID = 3.; //
 
 // RICH
 double rich_radius = 100.;
-double rich_length = 200.;
+double rich_length = 280.;
 
 // RICH ele pt acceptance
 // double rich_Ele_pt_cut = 1.8; // [GeV/c]
@@ -79,23 +87,31 @@ double rich_PionRejection_p_cut = 1.0; // [GeV/c]
 
 
 
-// PID Scenarios           different pt cuts           different PID scenarios               using iTOF layer         only TOF, RICH, both            use only PS
-bool useTOFPID[]        = {/*kTRUE,   kTRUE,     */  /*kTRUE,  kTRUE,  kTRUE,   kTRUE   */   /* kTRUE,   kTRUE  */    /*kTRUE,  kFALSE,*/ /*kTRUE  */   kFALSE };
-bool useRICHPID[]       = {/*kFALSE,  kFALSE,    */  /*kFALSE, kTRUE,  kTRUE,   kTRUE   */   /* kFALSE,  kFALSE */    /*kFALSE, kTRUE, */ /*kTRUE  */   kFALSE };
-bool usePreShPID[]      = {/*kFALSE,  kFALSE,    */  /*kFALSE, kFALSE, kFALSE,  kFALSE  */   /* kFALSE,  kFALSE */    /*kFALSE, kFALSE,*/ /*kFALSE */   kTRUE  };
-double nSigmaTOFEle[]   = {/*3.0,     3.0,       */  /*  3.0,    3.0,    3.0,     3.0   */   /*  3.0,    3.0    */    /*  3.0,    3.0, */ /*  3.0  */     3.0  };
-double nSigmaTOFPi[]    = {/*3.0,     3.0,       */  /*  3.0,    3.0,    3.0,     3.0   */   /*  3.0,    3.0    */    /*  3.0,    3.0, */ /*  3.0  */     3.0  };
-double nSigmaRICHEle[]  = {/*3.0,     3.0,       */  /*  3.0,    3.0,    3.0,     3.0   */   /*  0.0,    0.0    */    /*  3.0,    3.0, */ /*  3.0  */     3.0  };
-double nSigmaRICHPi[]   = {/*4.0,     4.0,       */  /*  3.0,    3.0,    3.5,     4.0   */   /*  99.,    99.    */    /*  4.0,    4.0, */ /*  4.0  */     4.0  };
-double PtCut02[]        = {/*0.04,    0.08,      */  /*  0.03,   0.03,   0.03,    0.03  */   /*  0.04,   0.0    */    /*  0.08,   0.08,*/ /*  0.08 */     0.08 };
-double PtCut05[]        = {/*0.2,     0.08,      */  /*  0.03,   0.03,   0.03,    0.03  */   /*  0.08,   0.0    */    /*  0.2,    0.2, */ /*  0.2  */     0.2  };
-double PtCut20[]        = {/*0.2,     0.08,      */  /*  0.03,   0.03,   0.03,    0.03  */   /*  0.08,   0.0    */    /*  0.2,    0.2, */ /*  0.3  */     0.3  };
+// PID Scenarios        =    study eta<1.75 w/woPF TOF/RICH/PS                      compare eta acceptance with MC PID                               different PF pt cuts                       /*      TOF, RICH,w wo PID */           different pt cuts           different PID scenarios                 using iTOF layer         only TOF, RICH, both          use only PS   use only MC PID          TOF+PS
+bool bUseTrackEff       =                 kTRUE                               /*                       kFALSE                         */  /*                      kTRUE                      */ /*           kFALSE        */                                                                                                                                                                                ;
+bool useMCPID[]         = {   kFALSE, /*kFALSE,*/ kFALSE, /*kFALSE,*/ kFALSE  /*  kTRUE,   kTRUE,   kTRUE,   kTRUE,   kTRUE,   kTRUE  */  /* kFALSE, kFALSE, kFALSE, kFALSE, kFALSE, kFALSE  */ /*   kTRUE,  kTRUE,  kTRUE */                                                                                                                                                                               };
+bool usePreFilter[]     = {    kTRUE, /* kTRUE,*/ kFALSE, /*kFALSE,*/  kTRUE  /*  kTRUE,   kTRUE,   kTRUE,   kTRUE,   kTRUE,   kTRUE  */  /* kFALSE,  kTRUE,  kTRUE,  kTRUE,  kTRUE,  kTRUE  */ /*  kFALSE, kFALSE, kFALSE */                                                                                                                                                                               };
+bool useTOFPID[]        = {    kTRUE, /* kTRUE,*/  kTRUE, /* kTRUE,*/  kTRUE  /* kFALSE,  kFALSE,  kFALSE,  kFALSE,  kFALSE,  kFALSE  */  /*  kTRUE,  kTRUE,  kTRUE,  kTRUE,  kTRUE,  kTRUE  */ /*   kTRUE, kFALSE, kFALSE */     /*kTRUE,   kTRUE,     */  /*kTRUE,  kTRUE ,  kTRUE,   kTRUE */    /* kTRUE  ,   kTRUE */   /*kTRUE , kFALSE,*/ /*kTRUE  */   /*kFALSE*/    /*   kFALSE*/      /* kFALSE */};
+bool useRICHPID[]       = {    kTRUE, /* kTRUE,*/  kTRUE, /* kTURE,*/  kTRUE  /* kFALSE,  kFALSE,  kFALSE,  kFALSE,  kFALSE,  kFALSE  */  /*  kTRUE,  kTRUE,  kTRUE,  kTRUE,  kTRUE,  kTRUE  */ /*  kFALSE,  kTRUE, kFALSE */     /*kFALSE,  kFALSE,    */  /*kFALSE, kTRUE ,  kTRUE,   kTRUE */    /* kFALSE ,  kFALSE */   /*kFALSE, kTRUE, */ /*kTRUE  */   /*kFALSE*/    /*   kFALSE*/      /* kFALSE */};
+bool usePreShPID[]      = {   kFALSE, /* kTRUE,*/ kFALSE, /* kTRUE,*/ kFALSE  /* kFALSE,  kFALSE,  kFALSE,  kFALSE,  kFALSE,  kFALSE  */  /* kFALSE, kFALSE, kFALSE, kFALSE, kFALSE, kFALSE  */ /*  kFALSE, kFALSE, kFALSE */     /*kFALSE,  kFALSE,    */  /*kFALSE, kFALSE, kFALSE,  kFALSE */    /* kFALSE ,  kFALSE */   /*kFALSE, kFALSE,*/ /*kFALSE */   /*kTRUE */    /*  kFALSE */      /*  kTRUE */};
+double nSigmaTOFEle[]   = {      3.0, /*   3.0,*/    3.0, /*   3.0,*/    3.0  /*    3.0,     3.0,     3.0,     3.0,     3.0,     3.0  */  /*    3.0,    3.0,    3.0,    3.0,    3.0,    3.0  */ /*     3.0,    3.0,    3.0 */     /*3.0,     3.0,       */  /*  3.0,    3.0 ,    3.0,     3.0 */    /*  3.0   ,    3.0  */   /*  3.0 ,   3.0, */ /*  3.0  */   /*  3.0 */    /*   -99.  */      /*    3.0 */};
+double nSigmaTOFPi[]    = {      3.0, /*   3.0,*/    3.0, /*   3.0,*/    3.0  /*    3.0,     3.0,     3.0,     3.0,     3.0,     3.0  */  /*    3.0,    3.0,    3.0,    3.0,    3.0,    3.0  */ /*     3.0,    3.0,    3.0 */     /*3.0,     3.0,       */  /*  3.0,    3.0 ,    3.0,     3.0 */    /*  3.0   ,    3.0  */   /*  3.0 ,   3.0, */ /*  3.0  */   /*  3.0 */    /*   -99.  */      /*    3.0 */};
+double nSigmaRICHEle[]  = {      3.0, /*   3.0,*/    3.0, /*   3.0,*/    3.0  /*    3.0,     3.0,     3.0,     3.0,     3.0,     3.0  */  /*    3.0,    3.0,    3.0,    3.0,    3.0,    3.0  */ /*     3.0,    3.0,    3.0 */     /*3.0,     3.0,       */  /*  3.0,    3.0 ,    3.0,     3.0 */    /*  0.0   ,    0.0  */   /*  3.0 ,   3.0, */ /*  3.0  */   /*  3.0 */    /*   -99.  */      /*    3.0 */};
+double nSigmaRICHPi[]   = {      4.0, /*   4.0,*/    4.0, /*   4.0,*/    4.0  /*    4.0,     4.0,     4.0,     4.0,     4.0,     4.0  */  /*    4.0,    4.0,    4.0,    4.0,    4.0,    4.0  */ /*     4.0,    4.0,    4.0 */     /*4.0,     4.0,       */  /*  3.0,    3.0 ,    3.5,     4.0 */    /*  99.   ,    99.  */   /*  4.0 ,   4.0, */ /*  4.0  */   /*  4.0 */    /*   -99.  */      /*    4.0 */};
+double PtCut02[]        = {     0.08, /*  0.08,*/   0.08, /*  0.08,*/   0.08  /*   0.08,    0.08,    0.08,    0.08,    0.08,    0.08  */  /*   0.08,   0.08,   0.08,   0.08,   0.08,   0.08  */ /*    0.08,   0.08,   0.08 */     /*0.04,    0.08,      */  /*  0.03,   0.03,   0.03,     0.3 */    /*  0.04  ,   0.0   */   /*  0.08,   0.08,*/ /*  0.08 */   /*  0.08*/    /*   0.2   */      /*   0.08 */};
+double PtCut05[]        = {      0.2, /*   0.2,*/    0.2, /*   0.2,*/    0.2  /*    0.2,     0.2,     0.2,     0.2,     0.2,     0.2  */  /*    0.2,    0.2,    0.2,    0.2,    0.2,    0.2  */ /*     0.2,    0.2,    0.2 */     /*0.2,     0.08,      */  /*  0.03,   0.03,   0.03,     0.3 */    /*  0.08  ,   0.0   */   /*  0.2 ,   0.2, */ /*  0.2  */   /*  0.2 */    /*   0.2   */      /*    0.2 */};
+double PtCut20[]        = {      0.3, /*   0.3,*/    0.3, /*   0.3,*/    0.3  /*    0.3,     0.3,     0.3,     0.3,     0.3,     0.3  */  /*    0.3,    0.3,    0.3,    0.3,    0.3,    0.3  */ /*     0.3,    0.3,    0.3 */     /*0.2,     0.08,      */  /*  0.03,   0.03,   0.03,     0.3 */    /*  0.08  ,   0.0   */   /*  0.2 ,   0.2, */ /*  0.3  */   /*  0.3 */    /*   0.2   */      /*    0.3 */};
+double EtaCut[]         = {     1.75, /*  1.75,*/   1.75, /*  1.75,*/   1.75  /*    0.8,    1.25,    1.75,     2.5,     3.0,     4.0  */  /*    0.8,    0.8,    0.8,    0.8,    0.8,    0.8  */ /*     0.8,    0.8,    0.8 */                                                                                                                                                                               };
+double usePFtrackVec[]  = {   kFALSE, /*kFALSE,*/ kFALSE, /*kFALSE,*/  kTRUE                                                              /* kFALSE, kFALSE,  kTRUE,  kTRUE,  kTRUE,  kTRUE  */ /*  kFALSE, kFALSE, kFALSE */                                                                                                                                                                               };
+double pf_pt_cut[]      = {     0.08, /*  0.08,*/   0.08, /*  0.08,*/   0.02  /*   0.08,    0.08,    0.08,    0.08,    0.08,    0.08  */  /*   0.00,   0.08,   0.02,   0.02,   0.02,   0.02  */ /*    0.00,   0.00,   0.00 */             /* use small pt cut first in rising order */                                                                                                          /*    0.2 */};
+double pf_opAngle_cut[] = {      0.1, /*   0.1,*/    0.1, /*   0.1,*/    0.1                                                              /*   0.00,   0.08,   0.08,    0.1,   0.12,   0.12  */ /*    0.00,   0.00,   0.00 */                                                                                                                                                                               };     // opening angle < pf_opAngle_cut  [rad]      pair cut
+double pf_mass_cut[]    = {     0.05, /*  0.05,*/   0.05, /*  0.05,*/   0.05                                                              /*   0.00,   0.05,   0.05,   0.05,   0.05,   0.06  */ /*    0.00,   0.00,   0.00 */                                                                                                                                                                               };     // pair mass < of_mass_cut         [GeV/c^2]  pair cut
+
 // TOF pte > 0.04 B = 0.2 T (highest priority) or TOF pte > 0.08 B = 0.5 T
 // TOF RICH pte > 0.2 B = 0.5 T (highest priority) or TOF RICH pte > 0.08  B = 0.5 T
 
 // Eta cut (pseudorapidity)
 // double EtaCut = 1.1;
-double EtaCut = 0.8;
 
 
 
@@ -130,17 +146,6 @@ bool doPID(Track * track, bool useTOF, bool useRICH, double p_tofMaxAcc, double 
   }
   else RICHpid = false;
 
-  // bool a = fabs(hypot(track->XOuter * 0.1,track->YOuter * 0.1) - 100) < 0.001;
-  // bool b = fabs(track->ZOuter * 0.1) < 200;
-  // if(p < 0.1) {
-  //   cout << " TOFpid = " << TOFpid << ", RICHpid = " << RICHpid << endl;
-  //   cout << " PDG = " << track->PID << ", p = " << p << endl;
-  //   cout << " hasTOF = " << toflayer.hasTOF(*track) << ", hasRICH = " << richdetector.hasRICH(*track) << endl;
-  //   cout << " TOF NsigmaEle = " << PIDnsigmaTOF[0] << ", NsigmaPi = " << PIDnsigmaTOF[2] << endl;
-  //   cout << " RICH NsigmaEle = " << PIDnsigmaRICH[0] << ", NsigmaPi = " << PIDnsigmaRICH[2] << endl;
-  //   cout << " TOF hasTOF requirements: (fabs(r - mRadius) < 0.001 ) = " << a << ", (fabs(z) < mLength) = " << b << endl;
-  //   cout << endl;
-  // }
 
   return RICHpid || TOFpid;
 
@@ -149,7 +154,7 @@ bool doPID(Track * track, bool useTOF, bool useRICH, double p_tofMaxAcc, double 
   // ################## end of PID selection ##################
 }
 
-bool doiTOFPID(Track * track, bool useTOF, double p_tofMaxAcc, double p_tofPionRej, double nSigmaTOFele, double nSigmaTOFpi, o2::delphes::TOFLayer toflayer, std::array<float, 5> PIDnsigmaTOF){
+bool doTOFPID(Track * track, bool useTOF, double p_tofMaxAcc, double p_tofPionRej, double nSigmaTOFele, double nSigmaTOFpi, o2::delphes::TOFLayer toflayer, std::array<float, 5> PIDnsigmaTOF){
   double p = track->P;
   bool TOFpid = false;
   //TOF PID
@@ -191,21 +196,21 @@ bool hasStrangeAncestor(GenParticle *particle, TClonesArray *particles)
 
 
 // eta cut for tracks
-bool etaCut(Track *tr){
+bool etaCut(Track *tr, Int_t iSce){
   // evaluate as true if criterion is passed
-  bool eta = abs(tr->Eta) < EtaCut;
+  bool eta = abs(tr->Eta) < EtaCut[iSce];
   return (eta);
 }
 // eta cut for particles
-bool etaCut(GenParticle *pa){
+bool etaCut(GenParticle *pa, Int_t iSce){
   // evaluate as true if criterion is passed
-  bool eta = abs(pa->Eta) < EtaCut;
+  bool eta = abs(pa->Eta) < EtaCut[iSce];
   return (eta);
 }
 // eta cut for LorentzVector
-bool etaCut(TLorentzVector LV){
+bool etaCut(TLorentzVector LV, Int_t iSce){
   // evaluate as true if criterion is passed
-  bool eta = abs(LV.Eta()) < EtaCut;
+  bool eta = abs(LV.Eta()) < EtaCut[iSce];
   return (eta);
 }
 
@@ -225,7 +230,7 @@ bool kineCuts(Track *tr, Int_t iSce){
   if(Bz == 2) pt = tr->PT > PtCut02[iSce];
   else if(Bz == 5) pt = tr->PT > PtCut05[iSce];
   else if(Bz == 20) pt = tr->PT > PtCut20[iSce];
-  bool eta = abs(tr->Eta) < EtaCut;
+  bool eta = abs(tr->Eta) < EtaCut[iSce];
   // all have to be true
   return (pt && eta);
 }
@@ -238,7 +243,7 @@ bool kineCuts(GenParticle *pa, Int_t iSce){
   if(Bz == 2) pt = pa->PT > PtCut02[iSce];
   else if(Bz == 5) pt = pa->PT > PtCut05[iSce];
   else if(Bz == 20) pt = pa->PT > PtCut20[iSce];
-  bool eta = abs(pa->Eta) < EtaCut;
+  bool eta = abs(pa->Eta) < EtaCut[iSce];
   // all have to be true
   return (pt && eta);
 }
@@ -251,7 +256,7 @@ bool kineCuts(TLorentzVector LV, Int_t iSce){
   if(Bz == 2) pt = LV.Pt() > PtCut02[iSce];
   else if(Bz == 5) pt = LV.Pt() > PtCut05[iSce];
   else if(Bz == 20) pt = LV.Pt() > PtCut20[iSce];
-  bool eta = abs(LV.Eta()) < EtaCut;
+  bool eta = abs(LV.Eta()) < EtaCut[iSce];
   // all have to be true
   return (pt && eta);
 }
@@ -551,60 +556,44 @@ TLorentzVector  ApplySmearing(TObjArray* fArrResoPt, TObjArray* fArrResoEta, TOb
 
 
 // Pair histograms ULS
-std::string title2d = ";#it{m}_{ee} (GeV/#it{c}^{2});#it{p}_{T} (GeV/#it{c})";
+std::string title2d = ";#it{m}_{ee} (GeV/#it{c}^{2});#it{p}_{T,ee} (GeV/#it{c})";
 std::string title3d = ";#it{m}_{ee} (GeV/#it{c}^{2});#it{p}_{T,ee} (GeV/#it{c});DCA_{ee} (mm)";
 
 
 void dileptonPairingRec(std::vector<Track *> vec_track_neg,std::vector<Track *> vec_track_pos, bool pairULS, bool MCpidEle, TClonesArray *particles, Int_t iSce, TH1F* hf_weight_low_pt, TH1F* hf_weight_high_pt, TH1F* hlf_weight);
 void dileptonPairingGen(std::vector<GenParticle *> vec_track_neg,std::vector<GenParticle *> vec_track_pos, bool pairULS, TClonesArray *particles, Int_t iSce, TH1F* hf_weight_low_pt, TH1F* hf_weight_high_pt, TH1F* hlf_weight);
+void PreFilter(std::vector<Track *>* vec_track_neg,std::vector<Track *>* vec_track_pos,TClonesArray *particles, Int_t iPIDscenario, TH1* hBeforePF, TH1* hAfterPF);
+void FillSingleTrackHistos(std::vector<Track *>* vec, int iPID_scenario, TClonesArray *particles, TH1* hweightLFtoe, TH1* hweightHFtoe_lowerPt, TH1* hweightHFtoe_higherPt);
+
+
 
 // Pair histograms
-TH3F* hMPtDCA_ULS_gen[3];
-// TH3F* hMPtDCA_ULS_gen_primary[3];
-// TH3F* hMPtDCA_ULS_gen_heavy[3];
-// TH3F* hMPtDCA_ULS_gen_charm[3];
-// TH3F* hMPtDCA_ULS_gen_beauty[3];
-TH3F* hMPtDCA_ULS_rec[3];
-// TH3F* hMPtDCA_ULS_rec_primary[3];
-// TH3F* hMPtDCA_ULS_rec_heavy[3];
-// TH3F* hMPtDCA_ULS_rec_charm[3];
-// TH3F* hMPtDCA_ULS_rec_beauty[3];
-TH3F* hMPtDCA_ULS_rec_MCpidEle[3];
-TH3F* hMPtDCA_ULS_rec_MCpidEle_charmTOe[3];
-TH3F* hMPtDCA_ULS_rec_MCpidEle_beautyTOe[3];
-TH3F* hMPtDCA_ULS_rec_MCpidEle_hfTOe[3];
-TH3F* hMPtDCA_ULS_rec_MCpidEle_lfTOee[3];
-TH3F* hMPtDCA_ULS_rec_MCpidEle_ccTOee[3];
-TH3F* hMPtDCA_ULS_rec_MCpidEle_bbTOee[3];
-TH3F* hMPtDCA_ULS_rec_MCpidEle_hfTOee[3];
-TH3F* hMPtDCA_LS_gen[3];
-// TH3F* hMPtDCA_LS_gen_primary[3];
-// TH3F* hMPtDCA_LS_gen_heavy[3];
-// TH3F* hMPtDCA_LS_gen_charm[3];
-// TH3F* hMPtDCA_LS_gen_beauty[3];
-TH3F* hMPtDCA_LS_rec[3];
-// TH3F* hMPtDCA_LS_rec_primary[3];
-// TH3F* hMPtDCA_LS_rec_heavy[3];
-// TH3F* hMPtDCA_LS_rec_charm[3];
-// TH3F* hMPtDCA_LS_rec_beauty[3];
-TH3F* hMPtDCA_LS_rec_MCpidEle[3];
-// TH3F* hMPtDCA_LS_rec_MCpidEle_primary[3];
-// TH3F* hMPtDCA_LS_rec_MCpidEle_heavy[3];
-// TH3F* hMPtDCA_LS_rec_MCpidEle_charm[3];
-// TH3F* hMPtDCA_LS_rec_MCpidEle_beauty[3];
-// TH3F* hMPtDCA_LS_rec_misIDoneLeg[3];
-// TH3F* hMPtDCA_LS_rec_misIDtwoLeg[3];
-// TH3F* hMPtDCA_LS_rec_misIDPion[3];
-// TH3F* hMPtDCA_LS_rec_misIDhf[3];
+TH3F* hMPtDCA_ULS_gen[6];
+TH3F* hMPtDCA_ULS_rec[6];
+TH3F* hMPtDCA_ULS_rec_MCpidEle[6];
+TH3F* hMPtDCA_ULS_rec_MCpidEle_charmTOe[6];
+TH3F* hMPtDCA_ULS_rec_MCpidEle_beautyTOe[6];
+TH3F* hMPtDCA_ULS_rec_MCpidEle_hfTOe[6];
+TH3F* hMPtDCA_ULS_rec_MCpidEle_lfTOee[6];
+TH3F* hMPtDCA_ULS_rec_MCpidEle_ccTOee[6];
+TH3F* hMPtDCA_ULS_rec_MCpidEle_bbTOee[6];
+TH3F* hMPtDCA_ULS_rec_MCpidEle_hfTOee[6];
+TH3F* hMPtDCA_LS_gen[6];
+TH3F* hMPtDCA_LS_rec[6];
+TH3F* hMPtDCA_LS_rec_MCpidEle[6];
+// TH3F* hMPtDCA_LS_rec_misIDoneLeg[6];
+// TH3F* hMPtDCA_LS_rec_misIDtwoLeg[6];
+// TH3F* hMPtDCA_LS_rec_misIDPion[6];
+// TH3F* hMPtDCA_LS_rec_misIDhf[6];
 
-TH3F* hMPtDCA_LS_rec_charmTOe[3];
-TH3F* hMPtDCA_LS_rec_beautyTOe[3];
-TH3F* hMPtDCA_LS_rec_hfTOe[3];
-TH3F* hMPtDCA_LS_rec_lfTOee[3];
-TH3F* hMPtDCA_LS_rec_lfTOee_selectPDG[3];
-TH3F* hMPtDCA_LS_rec_ccTOee[3];
-TH3F* hMPtDCA_LS_rec_bbTOee[3];
-TH3F* hMPtDCA_LS_rec_hfTOee[3];
+TH3F* hMPtDCA_LS_rec_charmTOe[6];
+TH3F* hMPtDCA_LS_rec_beautyTOe[6];
+TH3F* hMPtDCA_LS_rec_hfTOe[6];
+TH3F* hMPtDCA_LS_rec_lfTOee[6];
+TH3F* hMPtDCA_LS_rec_lfTOee_selectPDG[6];
+TH3F* hMPtDCA_LS_rec_ccTOee[6];
+TH3F* hMPtDCA_LS_rec_bbTOee[6];
+TH3F* hMPtDCA_LS_rec_hfTOee[6];
 
 
 void anaEEstudy(
@@ -612,7 +601,7 @@ void anaEEstudy(
     const char *outputFile = "anaEEstudyLFcc.root" // merge output files after analysis was run to keep file size moderate
   )
 {
-  cout << " cout Bz = " << Bz << endl;
+  cout << "    Bz = " << Bz  << " kG"<< endl;
   // Stopwatch
   TStopwatch* watch = new TStopwatch;
   watch->Start();
@@ -634,6 +623,47 @@ void anaEEstudy(
   for (int iBin = 0; iBin < nEtaBins+1; iBin++) {eta_binning[iBin] = -maxEta + iBin * 2.* maxEta/nEtaBins; /* std::cout << eta_binning[iBin] << " eta bin border " << std::endl;  */}
   for (int iBin = 0; iBin < nPhiBins+1; iBin++) {phi_binning[iBin] = 0. + iBin * maxPhi/nPhiBins;      /* std::cout << phi_binning[iBin] << " phi bin border " << std::endl;  */}
 
+
+  // // // ptee
+  // for(Int_t i=0  ;i<40   ;i++) {
+  //   ptee_bin_c[i] = 0.005 * i;        //from 0 to 0.2 GeV/c, every 0.005 GeV/c
+  //   //printf("bin %f for %d\n",ptee_bin_c[i],i);
+  // }
+  // for(Int_t i=40  ;i<=520   ;i++) {
+  //   ptee_bin_c[i] = 0.01 * (i-  40) +  0.2;        //from 0.2 to 5 GeV/c, every 0.01 GeV/c
+  //   //printf("bin %f for %d\n",ptee_bin_c[i],i);
+  // }
+  // for(Int_t i=0  ;i<2   ;i++) {
+  //   mee_bin_c[i] = 4. *i;//from 0 to 2. GeV/c, every 0.02 GeV/c
+  // }
+  //
+  // // DCA
+  // for(int k = 0 ; k < 2; k++){
+  //   dca_bin_c[k] = k*10.;
+  // }
+
+  // ptee
+  for(Int_t i=0  ;i<5   ;i++) {
+    ptee_bin_c[i] = 0.02 * i;        //from 0 to 0.1 GeV/c, every 0.02 GeV/c
+    //printf("bin %f for %d\n",ptee_bin_c[i],i);
+  }
+  for(Int_t i=5  ;i<=105   ;i++) {
+    ptee_bin_c[i] = 0.1 * (i-  5) +  0.1;        //from 0.1 to 10 GeV/c, every 0.1 GeV/c
+    //printf("bin %f for %d\n",ptee_bin_c[i],i);
+  }
+  // mee
+  for(Int_t i=0  ;i<100   ;i++) {
+    mee_bin_c[i] = 0.02 * (i-  0) +  0.0;//from 0 to 2. GeV/c, every 0.02 GeV/c
+  }
+  for(Int_t i=100  ;i<=120   ;i++) {
+    mee_bin_c[i] = 0.1 * (i-  100) +  2.0;//from 2 to 4. GeV/c, every 0.1 GeV/c
+  }
+  // DCA
+  for(int k = 0 ; k < 101; k++){
+    dca_bin_c[k] = k*0.1;
+  }
+
+
   // ptee
   // for(Int_t i=0  ;i<4   ;i++) {
   //   ptee_bin_c[i] = 0.025 * (i-  0) +  0.0;//from 0 to 0.075 GeV/c, every 0.025 GeV/c
@@ -644,27 +674,27 @@ void anaEEstudy(
   //   //printf("bin %f for %d\n",ptee_bin_c[i],i);
   // }
 
-  for(Int_t i=0  ;i<10   ;i++) {
-    ptee_bin_c[i] = 0.01 * (i-  0) +  0.0;//from 0 to 0.1 GeV/c, every 0.01 GeV/c
-    //printf("bin %f for %d\n",ptee_bin_c[i],i);
-  }
-  for(Int_t i=10 ;i<20  ;i++) {
-    ptee_bin_c[i] = 0.02  * (i- 10) +  0.1;//from 0.1 to 0.3 GeV/c, evety 0.02 GeV/c
-    //printf("bin %f for %d\n",ptee_bin_c[i],i);
-  }
-  for(Int_t i=20 ;i<215  ;i++) {
-    ptee_bin_c[i] = 0.05  * (i- 20) +  0.3;//from 0.3 to 10 GeV/c, evety 0.05 GeV/c
-    //printf("bin %f for %d\n",ptee_bin_c[i],i);
-  }
-
-  // mee
-  for(Int_t k = 0 ; k < 401; k++){
-    mee_bin_c[k] = k*0.01; // 4./400.
-  }
-  // DCA
-  for(int k = 0 ; k < 201; k++){
-    dca_bin_c[k] = k*0.1;
-  }
+  // for(Int_t i=0  ;i<10   ;i++) {
+  //   ptee_bin_c[i] = 0.01 * (i-  0) +  0.0;//from 0 to 0.1 GeV/c, every 0.01 GeV/c
+  //   //printf("bin %f for %d\n",ptee_bin_c[i],i);
+  // }
+  // for(Int_t i=10 ;i<20  ;i++) {
+  //   ptee_bin_c[i] = 0.02  * (i- 10) +  0.1;//from 0.1 to 0.3 GeV/c, evety 0.02 GeV/c
+  //   //printf("bin %f for %d\n",ptee_bin_c[i],i);
+  // }
+  // for(Int_t i=20 ;i<215  ;i++) {
+  //   ptee_bin_c[i] = 0.05  * (i- 20) +  0.3;//from 0.3 to 10 GeV/c, evety 0.05 GeV/c
+  //   //printf("bin %f for %d\n",ptee_bin_c[i],i);
+  // }
+  //
+  // // mee
+  // for(Int_t k = 0 ; k < 401; k++){
+  //   mee_bin_c[k] = k*0.01; // 4./400.
+  // }
+  // // DCA
+  // for(int k = 0 ; k < 201; k++){
+  //   dca_bin_c[k] = k*0.1;
+  // }
 
 
   // Get pointers to branches used in this analysis
@@ -705,9 +735,9 @@ void anaEEstudy(
   TH1F* hweightLFtoe = (TH1F*) fOutputWeightsLF->Get("lftoe_weights_paper_data_ratio");
 
 
-  // inner TOF layer
-  o2::delphes::TOFLayer innertoflayer;
-  innertoflayer.setup(inner_tof_radius, inner_tof_length, inner_tof_sigmat,inner_tof_sigma0);
+  // // inner TOF layer
+  // o2::delphes::TOFLayer innertoflayer;
+  // innertoflayer.setup(inner_tof_radius, inner_tof_length, inner_tof_sigmat,inner_tof_sigma0);
 
   // outer TOF layer
   o2::delphes::TOFLayer toflayer;
@@ -725,6 +755,12 @@ void anaEEstudy(
   o2::delphes::PreShower preshower;
   preshower.setup();
 
+  bool bUseTOFPID = kFALSE;
+  bool bUseRICHPID = kFALSE;
+  if (std::all_of(std::begin(useTOFPID), std::end(useTOFPID), [](bool i){return i;}))  bUseTOFPID = kTRUE;
+  if (std::all_of(std::begin(useRICHPID), std::end(useRICHPID), [](bool i){return i;}))  bUseRICHPID = kTRUE;
+  cout << "    bUseTOFPID = " << bUseTOFPID << endl;
+  cout << "    bUseRICHPID = " << bUseRICHPID << endl;
 
   // smearer
   // look up tables are selected in generateEfficiencies.sh script
@@ -735,7 +771,7 @@ void anaEEstudy(
   smearer.loadTable(321, "./lutCovm.ka.dat");
   smearer.loadTable(2212, "./lutCovm.pr.dat");
 
-  smearer.useEfficiency(true);
+  smearer.useEfficiency(bUseTrackEff);
 
 
 
@@ -769,6 +805,8 @@ void anaEEstudy(
   auto hTrackPt_hasTOForRICH = new TH1F("hTrackPt_hasTOForRICH",";#it{p}_{T} (GeV/#it{c})",200,0.,0.2);
 
 
+
+
   // Check smearing of generated tracks
   auto hSmearing_For_Eff_pt = new TH2F("hSmearing_For_Eff_pt","(#it{p}_{T,gen}-#it{p}_{T,rec})/#it{p}_{T,gen};#it{p}_{T} (GeV/#it{c})",400,0.,4.,500,-0.5,0.5);
   auto hSmearing_For_Eff_phi_pos = new TH2F("hSmearing_For_Eff_phi_pos","#phi_{gen}-#phi_{rec};#it{p}_{T} (GeV/#it{c})",400,0.,4.,500,-0.4,0.1);
@@ -782,33 +820,21 @@ void anaEEstudy(
   TH3F* hTrack_ElePos_Rec_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hNegTrack_Rec_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hPosTrack_Rec_Pt_Eta_Phi[nPIDscenarios];
-  TH3F* hAllTracks_Rec_Pt_Eta_Phi[nPIDscenarios];
-  TH3F* hTrack_Ele_Rec_Pt_Eta_Phi[nPIDscenarios];
-  TH3F* hTrack_Pos_Rec_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hTrack_Muon_Rec_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hTrack_Pion_Rec_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hTrack_Kaon_Rec_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hTrack_Proton_Rec_Pt_Eta_Phi[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_primary_rec[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_primary_Ele_rec[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_primary_Pos_rec[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_hf_rec[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_hf_Ele_rec[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_hf_Pos_rec[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_charm_rec[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_charm_Ele_rec[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_charm_Pos_rec[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_beauty_rec[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_beauty_Ele_rec[nPIDscenarios];
-  // TH3F* hPt_Eta_Phi_beauty_Pos_rec[nPIDscenarios];
-  TH3F* hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID  = new TH3F("hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID",";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  TH3F* hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID  = new TH3F("hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID",";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  TH3F* hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID  = new TH3F("hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID",";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
+  TH3F* hAllTracks_Rec_Pt_Eta_Phi[nPIDscenarios];
+  TH3F* hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID[nPIDscenarios];
+  TH3F* hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID[nPIDscenarios];
+  TH3F* hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID[nPIDscenarios];
   TH3F* hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_afterPID[nPIDscenarios];
   TH3F* hTrack_ElePos_LF_Rec_Pt_Eta_Phi_afterPID[nPIDscenarios];
   TH3F* hTrack_ElePos_HF_Rec_Pt_Eta_Phi_afterPID[nPIDscenarios];
-  TH1F* hTrack_ElePos_Rec_Pt_hasPS[nPIDscenarios];
-
+  TH2F* hMeeOpAngle_RecULS_bPF[nPIDscenarios];
+  TH2F* hMeeOpAngle_RecULS_aPF[nPIDscenarios];
+  TH1F* hTracks_ElePos_Gen_inPFvector_Pt[nPIDscenarios];
+  TH1F* hTracks_ElePos_Rec_inPFvector_Pt[nPIDscenarios];
 
   for (int j = 0; j < nPIDscenarios; ++j){
     hAfterKineCuts_Pt_Eta_Phi_rec[j] = new TH3F(Form("hAfterKineCuts_Pt_Eta_Phi_rec_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
@@ -816,81 +842,54 @@ void anaEEstudy(
     hNegTrack_Rec_Pt_Eta_Phi[j] = new TH3F(Form("hNegTrack_Rec_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
     hPosTrack_Rec_Pt_Eta_Phi[j] = new TH3F(Form("hPosTrack_Rec_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
     hAllTracks_Rec_Pt_Eta_Phi[j] = new TH3F(Form("hAllTracks_Rec_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    hTrack_Ele_Rec_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Ele_Rec_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    hTrack_Pos_Rec_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Pos_Rec_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
     hTrack_Muon_Rec_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Muon_Rec_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
     hTrack_Pion_Rec_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Pion_Rec_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
     hTrack_Kaon_Rec_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Kaon_Rec_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
     hTrack_Proton_Rec_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Proton_Rec_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_primary_rec[j] = new TH3F(Form("hPt_Eta_Phi_primary_rec_sce%i",j+1), ";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_primary_Ele_rec[j] = new TH3F(Form("hPt_Eta_Phi_primary_Ele_rec_sce%i",j+1), ";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_primary_Pos_rec[j] = new TH3F(Form("hPt_Eta_Phi_primary_Pos_rec_sce%i",j+1), ";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_hf_rec[j] = new TH3F(Form("hPt_Eta_Phi_hf_rec_sce%i",j+1), ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_hf_Ele_rec[j] = new TH3F(Form("hPt_Eta_Phi_hf_Ele_rec_sce%i",j+1), ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_hf_Pos_rec[j] = new TH3F(Form("hPt_Eta_Phi_hf_Pos_rec_sce%i",j+1), ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_charm_rec[j] = new TH3F(Form("hPt_Eta_Phi_charm_rec_sce%i",j+1), ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_charm_Ele_rec[j] = new TH3F(Form("hPt_Eta_Phi_charm_Ele_rec_sce%i",j+1), ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_charm_Pos_rec[j] = new TH3F(Form("hPt_Eta_Phi_charm_Pos_rec_sce%i",j+1), ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_beauty_rec[j] = new TH3F(Form("hPt_Eta_Phi_beauty_rec_sce%i",j+1), ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_beauty_Ele_rec[j] = new TH3F(Form("hPt_Eta_Phi_beauty_Ele_rec_sce%i",j+1), ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    // hPt_Eta_Phi_beauty_Pos_rec[j] = new TH3F(Form("hPt_Eta_Phi_beauty_Pos_rec_sce%i",j+1), ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
+    hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID[j]  = new TH3F(Form("hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
+    hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID[j]  = new TH3F(Form("hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
+    hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID[j]  = new TH3F(Form("hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
     hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_afterPID[j] = new TH3F(Form("hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_afterPID_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
     hTrack_ElePos_LF_Rec_Pt_Eta_Phi_afterPID[j] = new TH3F(Form("hTrack_ElePos_LF_Rec_Pt_Eta_Phi_afterPID_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
     hTrack_ElePos_HF_Rec_Pt_Eta_Phi_afterPID[j] = new TH3F(Form("hTrack_ElePos_HF_Rec_Pt_Eta_Phi_afterPID_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-    hTrack_ElePos_Rec_Pt_hasPS[j]  = new TH1F(Form("hTrack_ElePos_Rec_Pt_hasPS_sce%i",j+1),";#it{p}_{T} (GeV/#it{c})", n_ptee_bin_c, ptee_bin_c);
+    hTracks_ElePos_Rec_inPFvector_Pt[j] = new TH1F(Form("hTracks_ElePos_Rec_inPFvector_Pt_sce%i",j+1),";#it{p}_{T} (GeV/#it{c})",n_ptee_bin_c,ptee_bin_c);
   }
 
 
   // Pair histograms
   for (int j = 0; j < nPIDscenarios; ++j){
   // Pair histograms ULS
-    hMPtDCA_ULS_gen[j]         = new TH3F(Form("hMPtDCA_ULS_gen_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_ULS_gen_primary[j] = new TH3F(Form("hMPtDCA_ULS_gen_primary_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_ULS_gen_heavy[j]   = new TH3F(Form("hMPtDCA_ULS_gen_heavy_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_ULS_gen_charm[j]   = new TH3F(Form("hMPtDCA_ULS_gen_charm_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_ULS_gen_beauty[j]  = new TH3F(Form("hMPtDCA_ULS_gen_beauty_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_ULS_rec[j]         = new TH3F(Form("hMPtDCA_ULS_rec_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_ULS_rec_primary[j] = new TH3F(Form("hMPtDCA_ULS_rec_primary_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_ULS_rec_heavy[j]   = new TH3F(Form("hMPtDCA_ULS_rec_heavy_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_ULS_rec_charm[j]   = new TH3F(Form("hMPtDCA_ULS_rec_charm_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_ULS_rec_beauty[j]  = new TH3F(Form("hMPtDCA_ULS_rec_beauty_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_ULS_rec_MCpidEle[j]         = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_ULS_rec_MCpidEle_charmTOe[j]  = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_charmTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_ULS_rec_MCpidEle_beautyTOe[j]  = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_beautyTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_ULS_rec_MCpidEle_hfTOe[j]   = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_hfTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_ULS_rec_MCpidEle_lfTOee[j] = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_lfTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_ULS_rec_MCpidEle_ccTOee[j] = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_ccTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_ULS_rec_MCpidEle_bbTOee[j] = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_bbTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_ULS_rec_MCpidEle_hfTOee[j] = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_hfTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_ULS_gen[j]         = new TH3F(Form("hMPtDCA_ULS_gen_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_ULS_rec[j]         = new TH3F(Form("hMPtDCA_ULS_rec_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_ULS_rec_MCpidEle[j]         = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_ULS_rec_MCpidEle_charmTOe[j]  = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_charmTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_ULS_rec_MCpidEle_beautyTOe[j]  = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_beautyTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_ULS_rec_MCpidEle_hfTOe[j]   = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_hfTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_ULS_rec_MCpidEle_lfTOee[j] = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_lfTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_ULS_rec_MCpidEle_ccTOee[j] = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_ccTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_ULS_rec_MCpidEle_bbTOee[j] = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_bbTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_ULS_rec_MCpidEle_hfTOee[j] = new TH3F(Form("hMPtDCA_ULS_rec_MCpidEle_hfTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
   // Pair histograms LS
-    hMPtDCA_LS_gen[j]         = new TH3F(Form("hMPtDCA_LS_gen_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_gen_primary[j] = new TH3F(Form("hMPtDCA_LS_gen_primary_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_gen_heavy[j]   = new TH3F(Form("hMPtDCA_LS_gen_heavy_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_gen_charm[j]   = new TH3F(Form("hMPtDCA_LS_gen_charm_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_gen_beauty[j]  = new TH3F(Form("hMPtDCA_LS_gen_beauty_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_LS_rec[j]         = new TH3F(Form("hMPtDCA_LS_rec_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_primary[j] = new TH3F(Form("hMPtDCA_LS_rec_primary_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_heavy[j]   = new TH3F(Form("hMPtDCA_LS_rec_heavy_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_charm[j]   = new TH3F(Form("hMPtDCA_LS_rec_charm_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_beauty[j]  = new TH3F(Form("hMPtDCA_LS_rec_beauty_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_LS_rec_MCpidEle[j]         = new TH3F(Form("hMPtDCA_LS_rec_MCpidEle_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_MCpidEle_primary[j] = new TH3F(Form("hMPtDCA_LS_rec_MCpidEle_primary_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_MCpidEle_heavy[j]   = new TH3F(Form("hMPtDCA_LS_rec_MCpidEle_heavy_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_MCpidEle_charm[j]   = new TH3F(Form("hMPtDCA_LS_rec_MCpidEle_charm_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_MCpidEle_beauty[j]  = new TH3F(Form("hMPtDCA_LS_rec_MCpidEle_beauty_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_misIDoneLeg[j]      = new TH3F(Form("hMPtDCA_LS_rec_misIDoneLeg_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_misIDtwoLeg[j]      = new TH3F(Form("hMPtDCA_LS_rec_misIDtwoLeg_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_misIDPion[j]        = new TH3F(Form("hMPtDCA_LS_rec_misIDPion_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    // hMPtDCA_LS_rec_misIDhf[j]          = new TH3F(Form("hMPtDCA_LS_rec_misIDhf_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_LS_gen[j]         = new TH3F(Form("hMPtDCA_LS_gen_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_LS_rec[j]         = new TH3F(Form("hMPtDCA_LS_rec_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_LS_rec_MCpidEle[j]         = new TH3F(Form("hMPtDCA_LS_rec_MCpidEle_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  // hMPtDCA_LS_rec_misIDoneLeg[j]      = new TH3F(Form("hMPtDCA_LS_rec_misIDoneLeg_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  // hMPtDCA_LS_rec_misIDtwoLeg[j]      = new TH3F(Form("hMPtDCA_LS_rec_misIDtwoLeg_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  // hMPtDCA_LS_rec_misIDPion[j]        = new TH3F(Form("hMPtDCA_LS_rec_misIDPion_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  // hMPtDCA_LS_rec_misIDhf[j]          = new TH3F(Form("hMPtDCA_LS_rec_misIDhf_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
 
-    hMPtDCA_LS_rec_charmTOe[j]        = new TH3F(Form("hMPtDCA_LS_rec_charmTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_LS_rec_beautyTOe[j]       = new TH3F(Form("hMPtDCA_LS_rec_beautyTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_LS_rec_hfTOe[j]           = new TH3F(Form("hMPtDCA_LS_rec_hfTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_LS_rec_lfTOee[j]           = new TH3F(Form("hMPtDCA_LS_rec_lfTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_LS_rec_lfTOee_selectPDG[j] = new TH3F(Form("hMPtDCA_LS_rec_lfTOee_selectPDG_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_LS_rec_ccTOee[j]           = new TH3F(Form("hMPtDCA_LS_rec_ccTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_LS_rec_bbTOee[j]           = new TH3F(Form("hMPtDCA_LS_rec_bbTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
-    hMPtDCA_LS_rec_hfTOee[j]           = new TH3F(Form("hMPtDCA_LS_rec_hfTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_LS_rec_charmTOe[j]        = new TH3F(Form("hMPtDCA_LS_rec_charmTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_LS_rec_beautyTOe[j]       = new TH3F(Form("hMPtDCA_LS_rec_beautyTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_LS_rec_hfTOe[j]           = new TH3F(Form("hMPtDCA_LS_rec_hfTOe_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_LS_rec_lfTOee[j]           = new TH3F(Form("hMPtDCA_LS_rec_lfTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_LS_rec_lfTOee_selectPDG[j] = new TH3F(Form("hMPtDCA_LS_rec_lfTOee_selectPDG_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_LS_rec_ccTOee[j]           = new TH3F(Form("hMPtDCA_LS_rec_ccTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_LS_rec_bbTOee[j]           = new TH3F(Form("hMPtDCA_LS_rec_bbTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+  hMPtDCA_LS_rec_hfTOee[j]           = new TH3F(Form("hMPtDCA_LS_rec_hfTOee_sce%i",j+1),title3d.c_str(),n_mee_bin_c,mee_bin_c,n_ptee_bin_c,ptee_bin_c,n_dca_bin_c,dca_bin_c);
+    // before/after prefilter plots
+    hMeeOpAngle_RecULS_bPF[j] = new TH2F(Form("hMeeOpAngle_RecULS_bPF_sce%i",j+1), ";#it{m}_{ee} GeV/#it{c}^{2};#phi mrad", 40, 0., 0.4, 28, 0. , 0.7);
+    hMeeOpAngle_RecULS_aPF[j] = new TH2F(Form("hMeeOpAngle_RecULS_aPF_sce%i",j+1), ";#it{m}_{ee} GeV/#it{c}^{2};#phi mrad", 40, 0., 0.4, 28, 0. , 0.7);
+
   }
 
 
@@ -903,38 +902,22 @@ void anaEEstudy(
     lRecPIDscenario[iPIDscenario]->SetOwner();
     lRecPIDscenario[iPIDscenario]->Add(hAfterKineCuts_Pt_Eta_Phi_rec[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hTrack_ElePos_Rec_Pt_Eta_Phi[iPIDscenario]);
+    lRecPIDscenario[iPIDscenario]->Add(hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID[iPIDscenario]);
+    lRecPIDscenario[iPIDscenario]->Add(hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID[iPIDscenario]);
+    lRecPIDscenario[iPIDscenario]->Add(hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_afterPID[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hTrack_ElePos_LF_Rec_Pt_Eta_Phi_afterPID[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hTrack_ElePos_HF_Rec_Pt_Eta_Phi_afterPID[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hNegTrack_Rec_Pt_Eta_Phi[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hPosTrack_Rec_Pt_Eta_Phi[iPIDscenario]);
-    lRecPIDscenario[iPIDscenario]->Add(hAllTracks_Rec_Pt_Eta_Phi[iPIDscenario]);
-    lRecPIDscenario[iPIDscenario]->Add(hTrack_Ele_Rec_Pt_Eta_Phi[iPIDscenario]);
-    lRecPIDscenario[iPIDscenario]->Add(hTrack_Pos_Rec_Pt_Eta_Phi[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hTrack_Muon_Rec_Pt_Eta_Phi[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hTrack_Pion_Rec_Pt_Eta_Phi[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hTrack_Kaon_Rec_Pt_Eta_Phi[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hTrack_Proton_Rec_Pt_Eta_Phi[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_primary_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_primary_Ele_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_primary_Pos_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_hf_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_hf_Ele_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_hf_Pos_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_charm_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_charm_Ele_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_charm_Pos_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_beauty_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_beauty_Ele_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hPt_Eta_Phi_beauty_Pos_rec[iPIDscenario]);
-    lRecPIDscenario[iPIDscenario]->Add(hTrack_ElePos_Rec_Pt_hasPS[iPIDscenario]);
-
+    lRecPIDscenario[iPIDscenario]->Add(hAllTracks_Rec_Pt_Eta_Phi[iPIDscenario]);
+    lRecPIDscenario[iPIDscenario]->Add(hTracks_ElePos_Rec_inPFvector_Pt[iPIDscenario]);
 
     lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_rec_primary[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_rec_heavy[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_rec_charm[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_rec_beauty[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_rec_MCpidEle[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_rec_MCpidEle_charmTOe[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_rec_MCpidEle_beautyTOe[iPIDscenario]);
@@ -944,15 +927,7 @@ void anaEEstudy(
     lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_rec_MCpidEle_bbTOee[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_rec_MCpidEle_hfTOee[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_primary[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_heavy[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_charm[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_beauty[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_MCpidEle[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_MCpidEle_primary[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_MCpidEle_heavy[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_MCpidEle_charm[iPIDscenario]);
-    // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_MCpidEle_beauty[iPIDscenario]);
     // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_misIDoneLeg[iPIDscenario]);
     // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_misIDtwoLeg[iPIDscenario]);
     // lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_misIDPion[iPIDscenario]);
@@ -966,6 +941,9 @@ void anaEEstudy(
     lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_ccTOee[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_bbTOee[iPIDscenario]);
     lRecPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_rec_hfTOee[iPIDscenario]);
+    // add prefilter plots
+    lRecPIDscenario[iPIDscenario]->Add(hMeeOpAngle_RecULS_bPF[iPIDscenario]);
+    lRecPIDscenario[iPIDscenario]->Add(hMeeOpAngle_RecULS_aPF[iPIDscenario]);
     // listRecTracks->Add(lRecPIDscenario);
   }
 
@@ -976,30 +954,28 @@ void anaEEstudy(
 
   TH3F* hTrack_All_Gen_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hTrack_ElePos_Gen_Pt_Eta_Phi[nPIDscenarios];
+  TH3F* hTrack_ElePos_LF_Gen_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hTrack_ElePos_HF_Gen_Pt_Eta_Phi[nPIDscenarios];
+  TH3F* hTrack_ElePos_GenSmeared_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hTrack_Muon_Gen_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hTrack_Pion_Gen_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hTrack_Pion_Gen_Pt_Rap_Phi[nPIDscenarios];
   TH3F* hTrack_Kaon_Gen_Pt_Eta_Phi[nPIDscenarios];
   TH3F* hTrack_Proton_Gen_Pt_Eta_Phi[nPIDscenarios];
-  TH3F* hTrack_Ele_Gen_Pt_Eta_Phi[nPIDscenarios];
-  TH3F* hTrack_Pos_Gen_Pt_Eta_Phi[nPIDscenarios];
-  TH3F* hTrack_ElePos_GenSmeared_Pt_Eta_Phi[nPIDscenarios];
-  TH3F* hTrack_Ele_GenSmeared_Pt_Eta_Phi[nPIDscenarios];
-  TH3F* hTrack_Pos_GenSmeared_Pt_Eta_Phi[nPIDscenarios];
+
+
   for (int j = 0; j < nPIDscenarios; ++j) hTrack_All_Gen_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_All_Gen_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
   for (int j = 0; j < nPIDscenarios; ++j) hTrack_ElePos_Gen_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_ElePos_Gen_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
+  for (int j = 0; j < nPIDscenarios; ++j) hTrack_ElePos_LF_Gen_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_ElePos_LF_Gen_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
   for (int j = 0; j < nPIDscenarios; ++j) hTrack_ElePos_HF_Gen_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_ElePos_HF_Gen_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
+  for (int j = 0; j < nPIDscenarios; ++j) hTrack_ElePos_GenSmeared_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_ElePos_GenSmeared_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
   for (int j = 0; j < nPIDscenarios; ++j) hTrack_Muon_Gen_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Muon_Gen_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
   for (int j = 0; j < nPIDscenarios; ++j) hTrack_Pion_Gen_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Pion_Gen_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
   for (int j = 0; j < nPIDscenarios; ++j) hTrack_Pion_Gen_Pt_Rap_Phi[j] = new TH3F(Form("hTrack_Pion_Gen_Pt_Rap_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});y;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
   for (int j = 0; j < nPIDscenarios; ++j) hTrack_Kaon_Gen_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Kaon_Gen_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
   for (int j = 0; j < nPIDscenarios; ++j) hTrack_Proton_Gen_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Proton_Gen_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  for (int j = 0; j < nPIDscenarios; ++j) hTrack_Ele_Gen_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Ele_Gen_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  for (int j = 0; j < nPIDscenarios; ++j) hTrack_Pos_Gen_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Pos_Gen_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  for (int j = 0; j < nPIDscenarios; ++j) hTrack_ElePos_GenSmeared_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_ElePos_GenSmeared_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  for (int j = 0; j < nPIDscenarios; ++j) hTrack_Ele_GenSmeared_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Ele_GenSmeared_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  for (int j = 0; j < nPIDscenarios; ++j) hTrack_Pos_GenSmeared_Pt_Eta_Phi[j] = new TH3F(Form("hTrack_Pos_GenSmeared_Pt_Eta_Phi_sce%i",j+1),";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
+
+  for (int j = 0; j < nPIDscenarios; ++j) hTracks_ElePos_Gen_inPFvector_Pt[j] = new TH1F(Form("hTracks_ElePos_Gen_inPFvector_Pt_sce%i",j+1),";#it{p}_{T} (GeV/#it{c})",n_ptee_bin_c,ptee_bin_c);
 
 
   TList* lGenPIDscenario[nPIDscenarios];
@@ -1009,28 +985,18 @@ void anaEEstudy(
     lGenPIDscenario[iPIDscenario]->SetOwner();
     lGenPIDscenario[iPIDscenario]->Add(hTrack_All_Gen_Pt_Eta_Phi[iPIDscenario]);
     lGenPIDscenario[iPIDscenario]->Add(hTrack_ElePos_Gen_Pt_Eta_Phi[iPIDscenario]);
+    lGenPIDscenario[iPIDscenario]->Add(hTrack_ElePos_LF_Gen_Pt_Eta_Phi[iPIDscenario]);
     lGenPIDscenario[iPIDscenario]->Add(hTrack_ElePos_HF_Gen_Pt_Eta_Phi[iPIDscenario]);
+    lGenPIDscenario[iPIDscenario]->Add(hTrack_ElePos_GenSmeared_Pt_Eta_Phi[iPIDscenario]);
     lGenPIDscenario[iPIDscenario]->Add(hTrack_Muon_Gen_Pt_Eta_Phi[iPIDscenario]);
     lGenPIDscenario[iPIDscenario]->Add(hTrack_Pion_Gen_Pt_Eta_Phi[iPIDscenario]);
     lGenPIDscenario[iPIDscenario]->Add(hTrack_Pion_Gen_Pt_Rap_Phi[iPIDscenario]);
     lGenPIDscenario[iPIDscenario]->Add(hTrack_Kaon_Gen_Pt_Eta_Phi[iPIDscenario]);
     lGenPIDscenario[iPIDscenario]->Add(hTrack_Proton_Gen_Pt_Eta_Phi[iPIDscenario]);
-    lGenPIDscenario[iPIDscenario]->Add(hTrack_Ele_Gen_Pt_Eta_Phi[iPIDscenario]);
-    lGenPIDscenario[iPIDscenario]->Add(hTrack_Pos_Gen_Pt_Eta_Phi[iPIDscenario]);
-    lGenPIDscenario[iPIDscenario]->Add(hTrack_ElePos_GenSmeared_Pt_Eta_Phi[iPIDscenario]);
-    lGenPIDscenario[iPIDscenario]->Add(hTrack_Ele_GenSmeared_Pt_Eta_Phi[iPIDscenario]);
-    lGenPIDscenario[iPIDscenario]->Add(hTrack_Pos_GenSmeared_Pt_Eta_Phi[iPIDscenario]);
-
     lGenPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_gen[iPIDscenario]);
-    // lGenPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_gen_primary[iPIDscenario]);
-    // lGenPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_gen_heavy[iPIDscenario]);
-    // lGenPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_gen_charm[iPIDscenario]);
-    // lGenPIDscenario[iPIDscenario]->Add(hMPtDCA_ULS_gen_beauty[iPIDscenario]);
     lGenPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_gen[iPIDscenario]);
-    // lGenPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_gen_primary[iPIDscenario]);
-    // lGenPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_gen_heavy[iPIDscenario]);
-    // lGenPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_gen_charm[iPIDscenario]);
-    // lGenPIDscenario[iPIDscenario]->Add(hMPtDCA_LS_gen_beauty[iPIDscenario]);
+
+    lGenPIDscenario[iPIDscenario]->Add(hTracks_ElePos_Gen_inPFvector_Pt[iPIDscenario]);
     // listGenTracks->Add(lGenPIDscenario);
   }
 
@@ -1039,197 +1005,12 @@ void anaEEstudy(
     vecTListGenPIDscenarios.push_back(lGenPIDscenario[iPIDscenario]);
   }
 
-  // auto hPt_Eta_Phi_primary_gen = new TH3F("hPt_Eta_Phi_primary_gen", ";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  // auto hPt_Eta_Phi_primary_Ele_gen = new TH3F("hPt_Eta_Phi_primary_Ele_gen", ";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  // auto hPt_Eta_Phi_primary_Pos_gen = new TH3F("hPt_Eta_Phi_primary_Pos_gen", ";#it{p}_{T} (GeV/#it{c});#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  // auto hPt_Eta_Phi_hf_gen = new TH3F("hPt_Eta_Phi_hf_gen", ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  // auto hPt_Eta_Phi_hf_Ele_gen = new TH3F("hPt_Eta_Phi_hf_Ele_gen", ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  // auto hPt_Eta_Phi_hf_Pos_gen = new TH3F("hPt_Eta_Phi_hf_Pos_gen", ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  // auto hPt_Eta_Phi_charm_gen = new TH3F("hPt_Eta_Phi_charm_gen", ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  // auto hPt_Eta_Phi_charm_Ele_gen = new TH3F("hPt_Eta_Phi_charm_Ele_gen", ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  // auto hPt_Eta_Phi_charm_Pos_gen = new TH3F("hPt_Eta_Phi_charm_Pos_gen", ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  // auto hPt_Eta_Phi_beauty_gen = new TH3F("hPt_Eta_Phi_beauty_gen", ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  // auto hPt_Eta_Phi_beauty_Ele_gen = new TH3F("hPt_Eta_Phi_beauty_Ele_gen", ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-  // auto hPt_Eta_Phi_beauty_Pos_gen = new TH3F("hPt_Eta_Phi_beauty_Pos_gen", ";p_{T} (GeV/c);#eta;#varphi (rad)", n_ptee_bin_c, ptee_bin_c, nEtaBins, eta_binning, nPhiBins, phi_binning);
-
-  //
-  // auto hPrimaryM = new TH1F("hPrimaryM",";MotherPDG",1000,0.5,1000.5);
-  // auto hPrimaryGM = new TH1F("hPrimaryGM",";MotherPDG",1000,0.5,1000.5);
-  // auto hCharmMm = new TH1F("hCharmMm",";MotherPDG",101,399.5,500.5);
-  // auto hCharmMb = new TH1F("hCharmMb",";MotherPDG",1001,3099.5,5000.5);
-  //
-  // auto hCharmGM = new TH1F("hCharmGM",";MotherPDG",1000,0,10000);
-  // auto hBeautyM = new TH1F("hBeautyM",";MotherPDG",1000,0,10000);
-  // auto hBeautyGM = new TH1F("hBeautyGM",";MotherPDG",1000,0,10000);
-
-
-
-  // separat scale binning
-  Int_t nXBins = 504;
-  Int_t n10MeVBins=9;
-  Double_t *xBins    = new Double_t[nXBins+1];
-  Double_t xmin = 0.01;
-  Double_t x100MeV = 0.1;
-  Double_t xmax = 10.;
-  Double_t dx1   = (x100MeV-xmin)/(n10MeVBins);
-  Double_t dx2   = (xmax-x100MeV)/((Double_t)nXBins - n10MeVBins);
-
-  // binning log x axis (0-10) steps of 0.01 till 0.1 and 0.02 above
-  for (int i=0;i<=n10MeVBins;i++) {
-    Double_t x = xmin+ i*dx1;
-    xBins[i] = x ;
-  }
-  for (int i=1;i<=nXBins-n10MeVBins;i++) {
-    Double_t x = xBins[n10MeVBins]+ i*dx2;
-    xBins[n10MeVBins+i] = x ;
-  }
-
-  // binning NSigma (-25,25) in steps of 0.125
-  Int_t nYBins = 400;
-  Double_t dy = 50./400.;
-  Double_t yBins[nYBins+1];
-  for (int i = 0; i <= nYBins; i++) {
-    yBins[i] =  dy*i-25.;
-  }
 
 
   auto hM_Pt_sig_gen = new TH2F("hM_Pt_sig_gen",title2d.c_str(),300.,0,3.,200,0.,20.);
 
   TH1F* hTime0 = new TH1F("hTime0_sce%i",";t_{0} (ns)", 1000, -1., 1.);
 
-  // TOF histograms
-  auto hBetaP_beforeSmearing = new TH2F("hBetaP_beforeSmearing", ";#it{p} GeV/c;#beta", 500, 0., 10., 500, 0.1, 1.1);
-  auto hBetaP_afterSmearing = new TH2F("hBetaP_afterSmearing", ";#it{p} GeV/c;#beta", 500, 0., 10., 500, 0.1, 1.1);
-  TH2 *hNsigmaP_TOF[5];
-  TH2 *hNsigmaP_TOF_trueElec[5];
-  TH2 *hNsigmaP_TOF_trueMuon[5];
-  TH2 *hNsigmaP_TOF_truePion[5];
-  TH2 *hNsigmaP_TOF_trueKaon[5];
-  TH2 *hNsigmaP_TOF_trueProton[5];
-  TH2 *hNsigmaP_afterPIDcuts_TOF[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_TOF_trueElec[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_TOF_trueMuon[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_TOF_truePion[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_TOF_trueKaon[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_TOF_trueProton[5][nPIDscenarios];
-
-  auto hInnerBetaP_beforeSmearing = new TH2F("hInnerBetaP_beforeSmearing", ";#it{p} GeV/c;#beta", 500, 0., 10., 500, 0.1, 1.1);
-  auto hInnerBetaP_afterSmearing = new TH2F("hInnerBetaP_afterSmearing", ";#it{p} GeV/c;#beta", 500, 0., 10., 500, 0.1, 1.1);
-  TH2 *hNsigmaP_innerTOF[5];
-  TH2 *hNsigmaP_innerTOF_trueElec[5];
-  TH2 *hNsigmaP_innerTOF_trueMuon[5];
-  TH2 *hNsigmaP_innerTOF_truePion[5];
-  TH2 *hNsigmaP_innerTOF_trueKaon[5];
-  TH2 *hNsigmaP_innerTOF_trueProton[5];
-  TH2 *hNsigmaP_afterPIDcuts_innerTOF[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_innerTOF_trueElec[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_innerTOF_trueMuon[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_innerTOF_truePion[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_innerTOF_trueKaon[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_innerTOF_trueProton[5][nPIDscenarios];
-
-  const char *pname[5] = {"el", "mu", "pi", "ka", "pr"};
-  const char *plabel[5] = {"e", "#mu", "#pi", "K", "p"};
-
-  if(bPlotPIDhists){
-    for (int i = 0; i < 5; ++i){  // partilce type loop
-      hNsigmaP_TOF[i] = new TH2F(Form("hNsigmaP_%s_TOF", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      hNsigmaP_TOF_trueElec[i] = new TH2F(Form("hNsigmaP_%s_TOF_trueElec", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      hNsigmaP_TOF_trueMuon[i] = new TH2F(Form("hNsigmaP_%s_TOF_trueMuon", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      hNsigmaP_TOF_truePion[i] = new TH2F(Form("hNsigmaP_%s_TOF_truePion", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      hNsigmaP_TOF_trueKaon[i] = new TH2F(Form("hNsigmaP_%s_TOF_trueKaon", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      hNsigmaP_TOF_trueProton[i] = new TH2F(Form("hNsigmaP_%s_TOF_trueProton", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      if(bUseiTOF){
-        hNsigmaP_innerTOF[i] = new TH2F(Form("hNsigmaP_%s_innerTOF", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_innerTOF_trueElec[i] = new TH2F(Form("hNsigmaP_%s_innerTOF_trueElec", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_innerTOF_trueMuon[i] = new TH2F(Form("hNsigmaP_%s_innerTOF_trueMuon", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_innerTOF_truePion[i] = new TH2F(Form("hNsigmaP_%s_innerTOF_truePion", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_innerTOF_trueKaon[i] = new TH2F(Form("hNsigmaP_%s_innerTOF_trueKaon", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_innerTOF_trueProton[i] = new TH2F(Form("hNsigmaP_%s_innerTOF_trueProton", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      }
-
-      for (int j = 0; j < nPIDscenarios; ++j){ // PID scenatio loop
-        hNsigmaP_afterPIDcuts_TOF[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_TOF_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_afterPIDcuts_TOF_trueElec[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_TOF_trueElec_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_afterPIDcuts_TOF_trueMuon[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_TOF_trueMuon_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_afterPIDcuts_TOF_truePion[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_TOF_truePion_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_afterPIDcuts_TOF_trueKaon[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_TOF_trueKaon_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_afterPIDcuts_TOF_trueProton[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_TOF_trueProton_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        if(bUseiTOF){
-          hNsigmaP_afterPIDcuts_innerTOF[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_innerTOF_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-          hNsigmaP_afterPIDcuts_innerTOF_trueElec[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_innerTOF_trueElec_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-          hNsigmaP_afterPIDcuts_innerTOF_trueMuon[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_innerTOF_trueMuon_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-          hNsigmaP_afterPIDcuts_innerTOF_truePion[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_innerTOF_truePion_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-          hNsigmaP_afterPIDcuts_innerTOF_trueKaon[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_innerTOF_trueKaon_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-          hNsigmaP_afterPIDcuts_innerTOF_trueProton[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_innerTOF_trueProton_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        }
-      }
-    }
-  }
-
-  // RICH histograms
-  TH2 *hNsigmaBeta_RICH[5];
-  TH2 *hNsigmaP_RICH[5];
-  TH2 *hNsigmaP_RICH_trueElec[5];
-  TH2 *hNsigmaP_RICH_trueMuon[5];
-  TH2 *hNsigmaP_RICH_truePion[5];
-  TH2 *hNsigmaP_RICH_trueKaon[5];
-  TH2 *hNsigmaP_RICH_trueProton[5];
-  TH2 *hNsigmaP_afterPIDcuts_RICH[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_RICH_trueElec[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_RICH_trueMuon[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_RICH_truePion[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_RICH_trueKaon[5][nPIDscenarios];
-  TH2 *hNsigmaP_afterPIDcuts_RICH_trueProton[5][nPIDscenarios];
-  auto hCherenkovAngleP_beforeSmearing = new TH2F("hCherenkovAngleP_beforeSmearing", ";#it{p} GeV/c; cherenkov angle", 500, 0., 10., 200, 0., 0.4);
-  auto hCherenkovAngleP_afterSmearing = new TH2F("hCherenkovAngleP_afterSmearing", ";#it{p} GeV/c; cherenkov angle", 500, 0., 10., 200, 0., 0.4);
-
-  if(bPlotPIDhists){
-    for (int i = 0; i < 5; ++i)  hNsigmaBeta_RICH[i] = new TH2F(Form("hNsigmaBeta_%s_RICH", pname[i]), Form(";#beta ;n#sigma_{%s}", plabel[i]), 200, 0., 1.1, 400, -100., 100.);
-
-    for (int i = 0; i < 5; ++i) { // particle type loop
-      hNsigmaP_RICH[i] = new TH2F(Form("hNsigmaP_%s_RICH", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      hNsigmaP_RICH_trueElec[i] = new TH2F(Form("hNsigmaP_%s_RICH_trueElec", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      hNsigmaP_RICH_trueMuon[i] = new TH2F(Form("hNsigmaP_%s_RICH_trueMuon", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      hNsigmaP_RICH_truePion[i] = new TH2F(Form("hNsigmaP_%s_RICH_truePion", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      hNsigmaP_RICH_trueKaon[i] = new TH2F(Form("hNsigmaP_%s_RICH_trueKaon", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      hNsigmaP_RICH_trueProton[i] = new TH2F(Form("hNsigmaP_%s_RICH_trueProton", pname[i]), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      for (int j = 0; j < nPIDscenarios; ++j) { // PID scenatio loop
-        hNsigmaP_afterPIDcuts_RICH[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_RICH_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_afterPIDcuts_RICH_trueElec[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_RICH_trueElec_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_afterPIDcuts_RICH_trueMuon[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_RICH_trueMuon_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_afterPIDcuts_RICH_truePion[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_RICH_truePion_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_afterPIDcuts_RICH_trueKaon[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_RICH_trueKaon_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-        hNsigmaP_afterPIDcuts_RICH_trueProton[i][j] = new TH2F(Form("hNsigmaP_%s_afterPIDcuts_RICH_trueProton_sce%i", pname[i], j+1), Form(";#it{p} GeV/c;n#sigma_{%s}", plabel[i]), nXBins, xBins, nYBins, yBins);
-      }
-    }
-
-
-    for (int iPIDscenario = 0; iPIDscenario < nPIDscenarios; iPIDscenario++) {
-      for (int i = 0; i < 5; ++i) { // particle type loop
-        if(bUseiTOF){
-          lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_innerTOF[i][iPIDscenario]);
-          lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_innerTOF_trueElec[i][iPIDscenario]);
-          lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_innerTOF_trueMuon[i][iPIDscenario]);
-          lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_innerTOF_truePion[i][iPIDscenario]);
-          lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_innerTOF_trueKaon[i][iPIDscenario]);
-          lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_innerTOF_trueProton[i][iPIDscenario]);
-        }
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_TOF[i][iPIDscenario]);
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_TOF_trueElec[i][iPIDscenario]);
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_TOF_trueMuon[i][iPIDscenario]);
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_TOF_truePion[i][iPIDscenario]);
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_TOF_trueKaon[i][iPIDscenario]);
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_TOF_trueProton[i][iPIDscenario]);
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_RICH[i][iPIDscenario]);
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_RICH_trueElec[i][iPIDscenario]);
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_RICH_trueMuon[i][iPIDscenario]);
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_RICH_truePion[i][iPIDscenario]);
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_RICH_trueKaon[i][iPIDscenario]);
-        lRecPIDscenario[iPIDscenario]->Add(hNsigmaP_afterPIDcuts_RICH_trueProton[i][iPIDscenario]);
-      }
-    }
-  }
 
 
   std::vector<TList*> vecTListRecPIDscenarios;
@@ -1241,6 +1022,7 @@ void anaEEstudy(
   //-----------------------------------
   std::vector<Track *> vecElectron[nPIDscenarios],vecPositron[nPIDscenarios];
   std::vector<Track *> vecNegTracks[nPIDscenarios],vecPosTracks[nPIDscenarios];
+  std::vector<Track *> vecNegPFTracks[nPIDscenarios],vecPosPFTracks[nPIDscenarios];
   std::vector<GenParticle *> vecElectronGen[nPIDscenarios],vecPositronGen[nPIDscenarios], vecElectronGenSmeared[nPIDscenarios],vecPositronGenSmeared[nPIDscenarios];
   std::vector<GenParticle *> vecGen;
   std::vector<Track *> vecPIDtracks; // , vecTOFtracks
@@ -1259,10 +1041,7 @@ void anaEEstudy(
     nParticles->Fill(particles->GetEntries());
     // nTotalParticles = nTotalParticles + particles->GetEntries();
     // nTotalTracks = nTotalTracks + tracks->GetEntries();
-    // cout << "This event has " << particles->GetEntries() << " particles, and " << tracks->GetEntries() << " tracks, the total Number of Particles is now " << nTotalParticles << " and total number of tracks Tracks " << nTotalTracks << endl << endl;
 
-    // std::cout << " NTracks: " << tracks->GetEntries() << std::endl;
-    // std::cout << " NParticles: " << particles->GetEntries() << std::endl;
 
 
 
@@ -1319,7 +1098,9 @@ void anaEEstudy(
     // accept event if event has more then X particles within the FIT detector accaptance (2.2<eta&&eta< 5.0) || (-3.4<eta&&eta<-2.3)
     nParticlesFIT->Fill(numParticlesFIT);
     nParticlesMidRapidity->Fill(numParticlesMidRapidity);
-    if( numParticlesFIT < 5179 ) {   // PbPb: 5179,   pp: 58
+    // if( numParticlesFIT < 5179 ) {                                 // PbPb: 5179,   pp: 58    // centrality of 0-10%
+    // if( (numParticlesFIT < 584) || (numParticlesFIT > 1692) ) {       // PbPb: 584 - 1692,   pp: 58    // centrality of 40-60%
+    if( (numParticlesFIT < 1045) || (numParticlesFIT > 2549) ) {   // PbPb: 1045 - 2549,   pp: 58    // centrality of 30-50%
       vecGen.clear();
     continue;
     }
@@ -1373,6 +1154,12 @@ void anaEEstudy(
 
       double phiGen = TVector2::Phi_0_2pi(particle->Phi);
 
+      // Fill positve and negative vecotrs with tracks that don't have tracking efficiency, no smearing, true MC PID
+      for (Int_t iPID_scenario = 0; iPID_scenario < nPIDscenarios; iPID_scenario++) {
+        if( usePreFilter[iPID_scenario] && (abs(particle->PID) == 11) && (particle->PT >= pf_pt_cut[iPID_scenario]) && (fabs(particle->Eta) < 1.75) ){
+          hTracks_ElePos_Gen_inPFvector_Pt[iPID_scenario]->Fill(particle->PT);
+        }
+      }
 
       // Smearing generated particles
       //-----------------------------
@@ -1395,11 +1182,10 @@ void anaEEstudy(
       for (size_t iPID_scenario = 0; iPID_scenario < nPIDscenarios; iPID_scenario++) {
       if (abs(particle->PID) == 211 )  {
         double rap = etatorap(particle->PT,particle->Eta, 0.13957018); // use charged pion mass
-        if(abs(rap) <= 0.5) hTrack_Pion_Gen_Pt_Rap_Phi[iPID_scenario]->Fill(particle->PT,rap,phiGen,weight); // Pt Eta Phi of generated electrons + positrons
       }
 
         // apply eta acceptance cut
-        if(etaCut(particle)){
+        if(etaCut(particle, iPID_scenario)){
 
         // // kinematic cuts on particles
         // if (kineCuts(particle,iPID_scenario)){
@@ -1412,9 +1198,7 @@ void anaEEstudy(
           if (abs(particle->PID) == 211 )   hTrack_Pion_Gen_Pt_Eta_Phi[iPID_scenario]->Fill(particle->PT,particle->Eta,phiGen,weight); // Pt Eta Phi of generated electrons + positrons
           if (abs(particle->PID) == 321 )   hTrack_Kaon_Gen_Pt_Eta_Phi[iPID_scenario]->Fill(particle->PT,particle->Eta,phiGen,weight); // Pt Eta Phi of generated electrons + positrons
           if (abs(particle->PID) == 2212 )  hTrack_Proton_Gen_Pt_Eta_Phi[iPID_scenario]->Fill(particle->PT,particle->Eta,phiGen,weight); // Pt Eta Phi of generated electrons + positrons
-          if (particle->PID == 11)        hTrack_Ele_Gen_Pt_Eta_Phi[iPID_scenario]->Fill(particle->PT,particle->Eta,phiGen,weight);    // Pt Eta Phi of generated electrons
-          else if (particle->PID == -11)  hTrack_Pos_Gen_Pt_Eta_Phi[iPID_scenario]->Fill(particle->PT,particle->Eta,phiGen,weight);    // Pt Eta Phi of generated positrons
-
+          if((abs(particle->PID) == 11) && (abs(mPid) == 111 || abs(mPid) == 221 || abs(mPid) == 331 || abs(mPid) == 223 || abs(mPid) == 333 || abs(mPid) == 113) ) hTrack_ElePos_LF_Gen_Pt_Eta_Phi[iPID_scenario]->Fill(particle->PT,particle->Eta,phiGen,weight);
           if((abs(particle->PID) == 11) && (hasHeavyAncestor(particle, particles))) hTrack_ElePos_HF_Gen_Pt_Eta_Phi[iPID_scenario]->Fill(particle->PT,particle->Eta,phiGen,weight);
         }
 
@@ -1427,7 +1211,7 @@ void anaEEstudy(
 
         // // applying kinematic cuts on smeared LV vector
         // if (!kineCuts(LV_smeared,iPID_scenario)) continue;
-        if (etaCut(LV_smeared)) {
+        if (etaCut(LV_smeared, iPID_scenario)) {
           double phiGenSmear = TVector2::Phi_0_2pi(LV_smeared.Phi());
                           // cout << "gen pt eta phi: " << particle->PT << " " << particle->Eta << " " << phiGen << endl;
                           // cout << "gen smeared pt eta phi: " << LV_smeared.Pt() << " " << LV_smeared.Eta() << " " << phiGenSmear << endl;
@@ -1437,40 +1221,6 @@ void anaEEstudy(
           //----------------------------------------------------
           // look only at electrons
           if (abs(particle->PID) == 11 )  hTrack_ElePos_GenSmeared_Pt_Eta_Phi[iPID_scenario]->Fill(LV_smeared.Pt(),LV_smeared.Eta(),phiGenSmear,weight); // Pt Eta Phi of generated smeared electrons + positrons
-          if (particle->PID == 11)        hTrack_Ele_GenSmeared_Pt_Eta_Phi[iPID_scenario]->Fill(LV_smeared.Pt(),LV_smeared.Eta(),phiGenSmear,weight);    // Pt Eta Phi of generated smeared electrons
-          else if (particle->PID == -11)  hTrack_Pos_GenSmeared_Pt_Eta_Phi[iPID_scenario]->Fill(LV_smeared.Pt(),LV_smeared.Eta(),phiGenSmear,weight);    // Pt Eta Phi of generated smeared positrons
-
-
-          // fill histograms
-          // separate electrons & positrons originating from different light flavour (priamary), charm (cc) and buty (bb) decays
-          // if (!hasStrangeAncestor(particle, particles) && !hasHeavyAncestor(particle, particles)) {
-          //   hPt_Eta_Phi_primary_gen->Fill(particle->PT, particle->Eta, phiGen);
-          //   if(particle->PID == 11) hPt_Eta_Phi_primary_Ele_gen->Fill(particle->PT, particle->Eta, phiGen);
-          //   else if(particle->PID == -11) hPt_Eta_Phi_primary_Pos_gen->Fill(particle->PT, particle->Eta, phiGen);
-          // }
-          // else {
-          //     if (hasCharmAncestor(particle, particles) || hasBeautyAncestor(particle, particles)){
-          //       hPt_Eta_Phi_hf_gen->Fill(particle->PT, particle->Eta, phiGen);
-          //       if(particle->PID == 11) hPt_Eta_Phi_hf_Ele_gen->Fill(particle->PT, particle->Eta, phiGen);
-          //       else if(particle->PID == -11) hPt_Eta_Phi_hf_Pos_gen->Fill(particle->PT, particle->Eta, phiGen);
-          //     }
-          //     if(isCharm(mPid) && !hasBeautyAncestor(particle, particles)){
-          //       hPt_Eta_Phi_charm_gen->Fill(particle->PT, particle->Eta, phiGen);
-          //       if(particle->PID == 11) hPt_Eta_Phi_charm_Ele_gen->Fill(particle->PT, particle->Eta, phiGen);
-          //       else if(particle->PID == -11) hPt_Eta_Phi_charm_Pos_gen->Fill(particle->PT, particle->Eta, phiGen);
-          //     }
-          //     else if (isBeauty(mPid)) {
-          //       hPt_Eta_Phi_beauty_gen->Fill(particle->PT, particle->Eta, phiGen);
-          //       if(particle->PID == 11) hPt_Eta_Phi_beauty_Ele_gen->Fill(particle->PT, particle->Eta, phiGen);
-          //       else if(particle->PID == -11) hPt_Eta_Phi_beauty_Pos_gen->Fill(particle->PT, particle->Eta, phiGen);
-          //     }
-          //     else if (hasStrangeAncestor(particle, particles)) continue;
-          //     // else {
-          //     //   std::cout << particle->X << " " << particle->Y << " " << particle->Z << std::endl;
-          //     //   std::cout << " --- mother PDG     : " << mother->PID << std::endl;
-          //     //   std::cout << " --- grandmother PDG: " << gmother->PID << std::endl;
-          //     // }
-          // }
         }
 
         // fill generated smeared vectors
@@ -1492,53 +1242,15 @@ void anaEEstudy(
     //########## reconstructed Track Loop ##############
     //##################################################
 
-    // std::vector<GenParticle *> vecCorrespGenPar;
-    //
-    // for (Int_t itrack = 0; itrack < innertracks->GetEntries(); ++itrack)
-    // {
-    //   // get track and corresponding particle
-    //   // get track and corresponding particle
-    //   auto track = (Track *)innertracks->At(itrack);
-    //   auto particle = (GenParticle *)track->Particle.GetObject();
-    //   vecCorrespGenPar.push_back(particle);
-    //
-    //
-    //   double phiRec = TVector2::Phi_0_2pi(track->Phi);
-    //
-    //   if (useTOFPID){
-    //     // fill beta-p before semaring
-    //     auto p = track->P;
-    //     // inner TOF
-    //     auto betaInnerTOF = innertoflayer.getBeta(*track);
-    //     hInnerBetaP_beforeSmearing->Fill(p, betaInnerTOF);
-    //   }
-    //
-    //   // smear track if requested
-    //   if(abs(particle->PID) == 11 ) hBeforeSmearing_Pt_Eta_Phi_rec->Fill(track->PT,track->Eta,phiRec);
-    //   if (bSmear) if (!smearer.smearTrack(*track)) continue; // strange syntax, but works
-    //
-    //
-    //   // cut away tracks that are way off.
-    //   if (fabs(track->D0) > 0.4) continue; // adopt to just stay in the beampipe?
-    //   if (fabs(track->DZ) > 3.) continue;
-    //
-    //   // check if has TOF
-    //   // if (toflayer.hasTOF(*track)) vecTOFtracks.push_back(track);
-    //
-    //
-    //   // push all tracks into a vector.
-    //   vecPIDtracks.push_back(track);
-    // }
+
 
 
     // loop over tracks and fill vectors for electrons and positrons
     for (Int_t itrack = 0; itrack < tracks->GetEntries(); ++itrack)
     {
       // get track and corresponding particle
-      // get track and corresponding particle
       auto track = (Track *)tracks->At(itrack);
       auto particle = (GenParticle *)track->Particle.GetObject();
-      // if(std::find(vecCorrespGenPar.begin(), vecCorrespGenPar.end(), particle) != vecCorrespGenPar.end()) {cout << __LINE__ << "continue same GenParticle in InnerTrack list" << endl; continue;}
 
       //Get mother
       auto imother  = particle->M1;
@@ -1551,6 +1263,7 @@ void anaEEstudy(
       if(gmother) gmPid = gmother->PID;
 
       double phiRec = TVector2::Phi_0_2pi(track->Phi);
+
 
       // get weight to weight the contribution of LF and HF tracks
       Double_t weight;
@@ -1565,30 +1278,25 @@ void anaEEstudy(
       }
       else weight = GetWeight(hweightLFtoe, track->PT);
 
-      auto p = track->P;
-
-      if (useTOFPID){
-        // fill beta-p before semaring
-        // outer TOF
-        auto beta = toflayer.getBeta(*track);
-        hBetaP_beforeSmearing->Fill(p, beta);
-      }
-      if(bUseiTOF){
-        // inner TOF
-        auto betaInnerTOF = innertoflayer.getBeta(*track);
-        hInnerBetaP_beforeSmearing->Fill(p, betaInnerTOF);
+      // Fill positve and negative vecotrs with tracks that don't have tracking efficiency, no smearing, true MC PID
+      for (Int_t iPID_scenario = 0; iPID_scenario < nPIDscenarios; iPID_scenario++) {
+        if( usePreFilter[iPID_scenario] && (abs(particle->PID) == 11) && (track->PT >= pf_pt_cut[iPID_scenario]) && (fabs(particle->Eta) < 1.75) ){
+          if     (particle->Charge < 0) vecNegPFTracks[iPID_scenario].push_back(track);
+          else if(particle->Charge > 0) vecPosPFTracks[iPID_scenario].push_back(track);
+          hTracks_ElePos_Rec_inPFvector_Pt[iPID_scenario]->Fill(track->PT);
+        }
       }
 
-      if (useRICHPID){
-        // fill cherenkovAngle-p before semaring
-        auto measAngle = (richdetector.getMeasuredAngle(*track)).first;
-        hCherenkovAngleP_beforeSmearing->Fill(p,measAngle);
-      }
 
       // smear track if requested
       if(abs(particle->PID) == 11 ) hBeforeSmearing_Pt_Eta_Phi_rec->Fill(track->PT,track->Eta,phiRec,weight);
+      // cout << "track Pt,Eta,Phi: " << track->PT << ", " <<  track->Eta << ", " << track->Phi << endl;
       if (bSmear) if (!smearer.smearTrack(*track)) continue; // strange syntax, but works
-
+      if(TMath::IsNaN(track->Phi)){
+          // cout << "track: " << track << endl;
+          // cout << "track Pt,Eta,Phi: " << track->PT << ", " <<  track->Eta << ", " << track->Phi << endl;
+          continue;
+      }
 
       // cut away tracks that are way off.
       if (fabs(track->D0) > 0.4) continue; // adopt to just stay in the beampipe?
@@ -1602,7 +1310,7 @@ void anaEEstudy(
       vecPIDtracks.push_back(track);
     }
 
-    // vecCorrespGenPar.clear();
+
 
 
 
@@ -1656,26 +1364,19 @@ void anaEEstudy(
 
       if( (particle->Eta > -0.5 && particle->Eta<0.5) && particle->Charge != 0 ) hdNdeta_midrap_rec->Fill(particle->Eta,weight);
 
+      // if(track->PT < 0.1) continue; // debug code
       double phiRec = TVector2::Phi_0_2pi(track->Phi);
+      if(TMath::IsNaN(phiRec)) continue;
 
 
       if(abs(particle->PID) == 11 ) hAfterSmearing_Pt_Eta_Phi_rec->Fill(track->PT,track->Eta,phiRec,weight);
 
 
       auto p = track->P;
-      auto beta = toflayer.getBeta(*track);
-      auto betaInnerTOF = innertoflayer.getBeta(*track);
-      auto measAngle = (richdetector.getMeasuredAngle(*track)).first;
-
-      // fill beta-p after semaring
-      hBetaP_afterSmearing->Fill(p, beta);
-      if(bUseiTOF) hInnerBetaP_afterSmearing->Fill(p, betaInnerTOF);
-      // fill cherenkovAngle-p after semaring
-      hCherenkovAngleP_afterSmearing->Fill(p,measAngle);
 
       //make inner TOF PID
       std::array<float, 5> PIDdeltatInnerTOF, PIDnsigmaInnerTOF;
-      if(bUseiTOF) innertoflayer.makePID(*track, PIDdeltatInnerTOF, PIDnsigmaInnerTOF);
+      // if(bUseiTOF) innertoflayer.makePID(*track, PIDdeltatInnerTOF, PIDnsigmaInnerTOF);
 
       //make outer TOF PID
       std::array<float, 5> PIDdeltatTOF, PIDnsigmaTOF;
@@ -1692,68 +1393,27 @@ void anaEEstudy(
         hTrackP_hasTOForRICH->Fill(track->P,weight);
       }
 
-      // apply eta acceptance cut
-      if(!etaCut(track)) continue;
-
-      if( bPlotPIDhists && (innertoflayer.hasTOF(*track) || toflayer.hasTOF(*track) || richdetector.hasRICH(*track) )){
-
-        for (int i = 0; i < 5; ++i) {
-          // inner TOF
-          if(bUseiTOF && innertoflayer.hasTOF(*track)){
-                                                  hNsigmaP_innerTOF[i]->Fill(p, PIDnsigmaInnerTOF[i]);
-            if      (abs(particle->PID) == 11)    hNsigmaP_innerTOF_trueElec[i]->Fill(p, PIDnsigmaInnerTOF[i]);
-            else if (abs(particle->PID) == 13)    hNsigmaP_innerTOF_trueMuon[i]->Fill(p, PIDnsigmaInnerTOF[i]);
-            else if (abs(particle->PID) == 211)   hNsigmaP_innerTOF_truePion[i]->Fill(p, PIDnsigmaInnerTOF[i]);
-            else if (abs(particle->PID) == 321)   hNsigmaP_innerTOF_trueKaon[i]->Fill(p, PIDnsigmaInnerTOF[i]);
-            else if (abs(particle->PID) == 2212)  hNsigmaP_innerTOF_trueProton[i]->Fill(p, PIDnsigmaInnerTOF[i]);
-          }
-          // outer TOF
-          if(toflayer.hasTOF(*track)){
-                                                  hNsigmaP_TOF[i]->Fill(p, PIDnsigmaTOF[i]);
-            if      (abs(particle->PID) == 11)    hNsigmaP_TOF_trueElec[i]->Fill(p, PIDnsigmaTOF[i]);
-            else if (abs(particle->PID) == 13)    hNsigmaP_TOF_trueMuon[i]->Fill(p, PIDnsigmaTOF[i]);
-            else if (abs(particle->PID) == 211)   hNsigmaP_TOF_truePion[i]->Fill(p, PIDnsigmaTOF[i]);
-            else if (abs(particle->PID) == 321)   hNsigmaP_TOF_trueKaon[i]->Fill(p, PIDnsigmaTOF[i]);
-            else if (abs(particle->PID) == 2212)  hNsigmaP_TOF_trueProton[i]->Fill(p, PIDnsigmaTOF[i]);
-          }
-
-          // fill nsigma RICH  (before PID selection is applied)
-          if(richdetector.hasRICH(*track)){
-            hNsigmaP_RICH[i]->Fill(p, PIDnsigmaRICH[i]);
-                                                  hNsigmaBeta_RICH[i]->Fill(beta, PIDnsigmaRICH[i]);
-            if      (abs(particle->PID) == 11)    hNsigmaP_RICH_trueElec[i]->Fill(p, PIDnsigmaRICH[i]);
-            else if (abs(particle->PID) == 13)    hNsigmaP_RICH_trueMuon[i]->Fill(p, PIDnsigmaRICH[i]);
-            else if (abs(particle->PID) == 211)   hNsigmaP_RICH_truePion[i]->Fill(p, PIDnsigmaRICH[i]);
-            else if (abs(particle->PID) == 321)   hNsigmaP_RICH_trueKaon[i]->Fill(p, PIDnsigmaRICH[i]);
-            else if (abs(particle->PID) == 2212)  hNsigmaP_RICH_trueProton[i]->Fill(p, PIDnsigmaRICH[i]);
-          }
-        }
-      }
-
-      if(abs(particle->PID) == 11 ) {
-        if(abs(mPid) == 111)            hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID->Fill(track->PT,track->Eta,phiRec,weight);  // Pt Eta Phi of reconstructed electrons + positrons from Pi0 before PID
-        if(abs(mPid) == 111 || abs(mPid) == 221 || abs(mPid) == 331 || abs(mPid) == 223 || abs(mPid) == 333 || abs(mPid) == 113)
-                                      hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID->Fill(track->PT,track->Eta,phiRec,weight);   // Pt Eta Phi of reconstructed electrons + positrons from LF before PID (pi0,eta,etaprime,omega,phi,rho)
-        if(hasHeavyAncestor(particle, particles))
-                                      hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID->Fill(track->PT,track->Eta,phiRec,weight);   // Pt Eta Phi of reconstructed electrons + positrons from HF before PID
-      }
-
 
       for (size_t iPID_scenario = 0; iPID_scenario < nPIDscenarios; iPID_scenario++) {
 
-        // // kinatic cuts on tracks        (no pt cut on single electrons)
-        // if (!kineCuts(track, iPID_scenario)) continue;
+        // apply eta acceptance cut
+        if(!etaCut(track, iPID_scenario)) continue;
+
+
+        if(abs(particle->PID) == 11 ) {
+          if(abs(mPid) == 111)          hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);  // Pt Eta Phi of reconstructed electrons + positrons from Pi0 before PID
+          if(abs(mPid) == 111 || abs(mPid) == 221 || abs(mPid) == 331 || abs(mPid) == 223 || abs(mPid) == 333 || abs(mPid) == 113)
+                                        hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);   // Pt Eta Phi of reconstructed electrons + positrons from LF before PID (pi0,eta,etaprime,omega,phi,rho)
+          if(hasHeavyAncestor(particle, particles))
+                                        hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);   // Pt Eta Phi of reconstructed electrons + positrons from HF before PID
+        }
 
         if(abs(particle->PID) == 11 ) hAfterKineCuts_Pt_Eta_Phi_rec[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);
 
-        // look only at electrons
-        // if(abs(particle->PID) != 11 ) continue;
-
         // Apply PreShower electron selection
+        bool isElectronPreShower = false;
         if(usePreShPID[iPID_scenario]){
-          bool isElectronPreShower = false;
           if (preshower.hasPreShower(*track) ) isElectronPreShower = preshower.isElectron(*track,1800);
-          if (isElectronPreShower && abs(particle->PID) == 11) hTrack_ElePos_Rec_Pt_hasPS[iPID_scenario]->Fill(track->PT,weight);
         }
 
         //setting variables for i-th PID scenario
@@ -1765,44 +1425,73 @@ void anaEEstudy(
         double i_SigmaRICHEle = nSigmaRICHEle[iPID_scenario];
         double i_SigmaRICHPi = nSigmaRICHPi[iPID_scenario];
 
-        if(i_useTOFPID || i_useRICHPID){
-          if(!doPID(track, i_useTOFPID, i_useRICHPID, tof_EleAccep_p_cut, tof_PionRej_p_cut, rich_PionRejection_p_cut, i_SigmaTOFEle, i_SigmaTOFPi, i_SigmaRICHEle, i_SigmaRICHPi, toflayer, richdetector, PIDnsigmaTOF, PIDnsigmaRICH)) continue;
-          // if(!doiTOFPID(track, i_useTOFPID, itof_EleAccep_p_cut, tof_PionRej_p_cut, i_SigmaTOFEle, i_SigmaTOFPi, toflayer, PIDnsigmaTOF)) continue;
-          // cout << "### passed doiTOFPID() ###" << endl;
-        }
+        bool bool_doPID = false;
+        if(                       i_useRICHPID && !bUseiTOF && doPID(track, i_useTOFPID, i_useRICHPID, tof_EleAccep_p_cut, tof_PionRej_p_cut, rich_PionRejection_p_cut, i_SigmaTOFEle, i_SigmaTOFPi, i_SigmaRICHEle, i_SigmaRICHPi, toflayer, richdetector, PIDnsigmaTOF, PIDnsigmaRICH) ) bool_doPID = true;
+        else if(  i_useTOFPID && !i_useRICHPID && !bUseiTOF && doTOFPID(track, i_useTOFPID, tof_EleAccep_p_cut, tof_PionRej_p_cut, i_SigmaTOFEle, i_SigmaTOFPi, toflayer, PIDnsigmaTOF) ) bool_doPID = true;
+        else if(  i_useTOFPID &&                   bUseiTOF && doTOFPID(track, i_useTOFPID, itof_EleAccep_p_cut, tof_PionRej_p_cut, i_SigmaTOFEle, i_SigmaTOFPi, toflayer, PIDnsigmaTOF) ) bool_doPID = true;
 
-        // fill nsigma after PID cuts histograms    (after PID selection has been applied)
-        if(bPlotPIDhists) {
-          for (int i = 0; i < 5; ++i) {
-            // NSigma plots, separating for true particle ID
-            // inner TOF
-            if(bUseiTOF && innertoflayer.hasTOF(*track)){
-                                                   hNsigmaP_afterPIDcuts_innerTOF[i][iPID_scenario]->Fill(p, PIDnsigmaInnerTOF[i]);
-              if      (abs(particle->PID) == 11)   hNsigmaP_afterPIDcuts_innerTOF_trueElec[i][iPID_scenario]->Fill(p, PIDnsigmaInnerTOF[i]);
-              else if (abs(particle->PID) == 13)   hNsigmaP_afterPIDcuts_innerTOF_trueMuon[i][iPID_scenario]->Fill(p, PIDnsigmaInnerTOF[i]);
-              else if (abs(particle->PID) == 211)  hNsigmaP_afterPIDcuts_innerTOF_truePion[i][iPID_scenario]->Fill(p, PIDnsigmaInnerTOF[i]);
-              else if (abs(particle->PID) == 321)  hNsigmaP_afterPIDcuts_innerTOF_trueKaon[i][iPID_scenario]->Fill(p, PIDnsigmaInnerTOF[i]);
-              else if (abs(particle->PID) == 2212) hNsigmaP_afterPIDcuts_innerTOF_trueProton[i][iPID_scenario]->Fill(p, PIDnsigmaInnerTOF[i]);
-            }
-            // outer TOF
-            if(toflayer.hasTOF(*track)){
-                                                   hNsigmaP_afterPIDcuts_TOF[i][iPID_scenario]->Fill(p, PIDnsigmaTOF[i]);
-              if      (abs(particle->PID) == 11)   hNsigmaP_afterPIDcuts_TOF_trueElec[i][iPID_scenario]->Fill(p, PIDnsigmaTOF[i]);
-              else if (abs(particle->PID) == 13)   hNsigmaP_afterPIDcuts_TOF_trueMuon[i][iPID_scenario]->Fill(p, PIDnsigmaTOF[i]);
-              else if (abs(particle->PID) == 211)  hNsigmaP_afterPIDcuts_TOF_truePion[i][iPID_scenario]->Fill(p, PIDnsigmaTOF[i]);
-              else if (abs(particle->PID) == 321)  hNsigmaP_afterPIDcuts_TOF_trueKaon[i][iPID_scenario]->Fill(p, PIDnsigmaTOF[i]);
-              else if (abs(particle->PID) == 2212) hNsigmaP_afterPIDcuts_TOF_trueProton[i][iPID_scenario]->Fill(p, PIDnsigmaTOF[i]);
-            }
-            if(richdetector.hasRICH(*track)){
-                                                   hNsigmaP_afterPIDcuts_RICH[i][iPID_scenario]->Fill(p, PIDnsigmaRICH[i]);
-              if      (abs(particle->PID) == 11)   hNsigmaP_afterPIDcuts_RICH_trueElec[i][iPID_scenario]->Fill(p, PIDnsigmaRICH[i]);
-              else if (abs(particle->PID) == 13)   hNsigmaP_afterPIDcuts_RICH_trueMuon[i][iPID_scenario]->Fill(p, PIDnsigmaRICH[i]);
-              else if (abs(particle->PID) == 211)  hNsigmaP_afterPIDcuts_RICH_truePion[i][iPID_scenario]->Fill(p, PIDnsigmaRICH[i]);
-              else if (abs(particle->PID) == 321)  hNsigmaP_afterPIDcuts_RICH_trueKaon[i][iPID_scenario]->Fill(p, PIDnsigmaRICH[i]);
-              else if (abs(particle->PID) == 2212) hNsigmaP_afterPIDcuts_RICH_trueProton[i][iPID_scenario]->Fill(p, PIDnsigmaRICH[i]);
-            }
-          }
+        if ( (usePreShPID[iPID_scenario] || i_useTOFPID || i_useRICHPID) && ((isElectronPreShower == false) && (bool_doPID == false)) ) continue;
+        else if ( !(usePreShPID[iPID_scenario] || i_useTOFPID || i_useRICHPID) && !useMCPID[iPID_scenario] ) continue;
+        // if ( (isElectronPreShower == false) && (bool_doPID == false) &&  !useMCPID[iPID_scenario] ) continue;
+        if (useMCPID[iPID_scenario] && (abs(track->PID) != 11)) continue;
+
+        // fill track vector
+        if (track->Charge < 0) vecNegTracks[iPID_scenario].push_back(track);       //  vector of all reconstructed negative tracks
+        else if (track->Charge > 0) vecPosTracks[iPID_scenario].push_back(track);  //  vector of all reconstructed positve tracks
+
+      }
+    }
+    vecPIDtracks.clear();
+
+
+
+
+    // Apply PreFilter
+    for (int iPID_scenario = 0; iPID_scenario < nPIDscenarios; iPID_scenario++) {
+      if(usePreFilter[iPID_scenario] && !usePFtrackVec[iPID_scenario]){
+        PreFilter(&vecNegTracks[iPID_scenario], &vecPosTracks[iPID_scenario], particles, iPID_scenario, hMeeOpAngle_RecULS_bPF[iPID_scenario], hMeeOpAngle_RecULS_aPF[iPID_scenario]);
+      }
+      else if(usePreFilter[iPID_scenario] && usePFtrackVec[iPID_scenario]){
+        PreFilter(&vecNegPFTracks[iPID_scenario], &vecPosTracks[iPID_scenario], particles, iPID_scenario, hMeeOpAngle_RecULS_bPF[iPID_scenario], hMeeOpAngle_RecULS_aPF[iPID_scenario]);
+        PreFilter(&vecNegTracks[iPID_scenario], &vecPosPFTracks[iPID_scenario], particles, iPID_scenario, hMeeOpAngle_RecULS_bPF[iPID_scenario], hMeeOpAngle_RecULS_aPF[iPID_scenario]);
+        // PreFilter(&vecElectron[iPID_scenario], &vecPositron[iPID_scenario], particles, iPID_scenario, hMeeOpAngle_RecULS_bPF[iPID_scenario], hMeeOpAngle_RecULS_aPF[iPID_scenario]);
+      }
+      vecNegPFTracks[iPID_scenario].clear();
+      vecPosPFTracks[iPID_scenario].clear();
+    }
+
+
+
+
+    // fill single track histograms
+    for (int iPID_scenario = 0; iPID_scenario < nPIDscenarios; iPID_scenario++) {
+      // loop over negative track vector
+      for (int itrack = vecNegTracks[iPID_scenario].size()-1; itrack >= 0 ; itrack--) {
+
+        Track* track = (Track *) vecNegTracks[iPID_scenario].at(itrack);
+        auto particle = (GenParticle *)track->Particle.GetObject();
+
+        //Get mother
+        auto imother  = particle->M1;
+        auto mother   = imother != -1 ? (GenParticle *)particles->At(imother) : (GenParticle *)nullptr;
+        auto mPid     = mother->PID;
+
+        // get weight to weight the contribution of LF and HF tracks
+        Double_t weight;
+        if ( abs(particle->PID) == 11 && hasHeavyAncestor(particle, particles) ) {
+          if (particle->PT < 0.1)                             weight = 1.;
+          else if (particle->PT >= 0.1 && particle->PT < 0.6) weight = GetWeight(hweightHFtoe_lowerPt, track->PT);
+          else                                                weight = GetWeight(hweightHFtoe_higherPt, track->PT);
         }
+        else if ( abs(particle->PID) == 11 && !hasHeavyAncestor(particle, particles) ) {
+          if(mother->PT < 0.1) weight = 0.7;
+          else                 weight = GetWeight(hweightLFtoe, mother->PT);
+        }
+        else weight = GetWeight(hweightLFtoe, track->PT);
+
+        // if(track->PT < 0.1) continue; // debug code
+        double phiRec = TVector2::Phi_0_2pi(track->Phi);
+
 
         // fill histograms
                                     hAllTracks_Rec_Pt_Eta_Phi[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight); // Pt Eta Phi of all type of reconstructed particles
@@ -1820,70 +1509,81 @@ void anaEEstudy(
 
         // look only at electrons
         if(abs(particle->PID) == 11 ) {   // considering only electrons & positrons
-                                          hTrack_ElePos_Rec_Pt_Eta_Phi[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);  // Pt Eta Phi of reconstructed electrons + positrons
-          if (particle->PID == 11)        hTrack_Ele_Rec_Pt_Eta_Phi[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);     // Pt Eta Phi of reconstructed electrons
-          else if (particle->PID == -11)  hTrack_Pos_Rec_Pt_Eta_Phi[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);     // Pt Eta Phi of reconstructed positrons
+                                               hTrack_ElePos_Rec_Pt_Eta_Phi[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);  // Pt Eta Phi of reconstructed electrons + positrons
           if(abs(mPid) == 111)                 hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_afterPID[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);  // Pt Eta Phi of reconstructed electrons + positrons from Pi0
+          if(abs(mPid) == 111 || abs(mPid) == 221 || abs(mPid) == 331 || abs(mPid) == 223 || abs(mPid) == 333 || abs(mPid) == 113)
+                                               hTrack_ElePos_LF_Rec_Pt_Eta_Phi_afterPID[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);   // Pt Eta Phi of reconstructed electrons + positrons from LF (pi0,eta,etaprime,omega,phi,rho)
+          if(hasHeavyAncestor(particle, particles))
+                                               hTrack_ElePos_HF_Rec_Pt_Eta_Phi_afterPID[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);   // Pt Eta Phi of reconstructed electrons + positrons from HF
+        }
+
+        //apply pt cuts before filling vectors for pairing
+        if (!kineCuts(track, iPID_scenario)) {
+            vecNegTracks[iPID_scenario].erase(vecNegTracks[iPID_scenario].begin()+itrack);
+            continue;  // end itrack loop
+
+        }
+        if (particle->PID == 11 ) vecElectron[iPID_scenario].push_back(track);       // vector of reconstructed electrons
+      }
+
+      // loop over positve track vector
+      for (int itrack = vecPosTracks[iPID_scenario].size()-1; itrack >= 0 ; itrack--) {
+        Track* track = (Track *) vecPosTracks[iPID_scenario].at(itrack);
+        auto particle = (GenParticle *)track->Particle.GetObject();
+
+        //Get mother
+        auto imother  = particle->M1;
+        auto mother   = imother != -1 ? (GenParticle *)particles->At(imother) : (GenParticle *)nullptr;
+        auto mPid     = mother->PID;
+
+        // get weight to weight the contribution of LF and HF tracks
+        Double_t weight;
+        if ( abs(particle->PID) == 11 && hasHeavyAncestor(particle, particles) ) {
+          if (particle->PT < 0.1)                             weight = 1.;
+          else if (particle->PT >= 0.1 && particle->PT < 0.6) weight = GetWeight(hweightHFtoe_lowerPt, track->PT);
+          else                                                weight = GetWeight(hweightHFtoe_higherPt, track->PT);
+        }
+        else if ( abs(particle->PID) == 11 && !hasHeavyAncestor(particle, particles) ) {
+          if(mother->PT < 0.1) weight = 0.7;
+          else                 weight = GetWeight(hweightLFtoe, mother->PT);
+        }
+        else weight = GetWeight(hweightLFtoe, track->PT);
+
+        // if(track->PT < 0.1) continue; // debug code
+        double phiRec = TVector2::Phi_0_2pi(track->Phi);
+
+
+        // fill histograms
+                                    hAllTracks_Rec_Pt_Eta_Phi[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight); // Pt Eta Phi of all type of reconstructed particles
+        if     (track->Charge < 0)  hNegTrack_Rec_Pt_Eta_Phi[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);  // Pt Eta Phi of reconstructed negative tracks
+        else if(track->Charge > 0)  hPosTrack_Rec_Pt_Eta_Phi[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);  // Pt Eta Phi of reconstructed positive tracks
+
+        // Pt Eta Phi plots for different type of particles
+        if      (abs(particle->PID) == 13)    hTrack_Muon_Rec_Pt_Eta_Phi[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);
+        else if (abs(particle->PID) == 211)   hTrack_Pion_Rec_Pt_Eta_Phi[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);
+
+
+        // look only at electrons
+        if(abs(particle->PID) == 11 ) {   // considering only electrons & positrons
+                                          hTrack_ElePos_Rec_Pt_Eta_Phi[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);  // Pt Eta Phi of reconstructed electrons + positrons
+          if(abs(mPid) == 111)            hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_afterPID[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);  // Pt Eta Phi of reconstructed electrons + positrons from Pi0
           if(abs(mPid) == 111 || abs(mPid) == 221 || abs(mPid) == 331 || abs(mPid) == 223 || abs(mPid) == 333 || abs(mPid) == 113)
                                           hTrack_ElePos_LF_Rec_Pt_Eta_Phi_afterPID[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);   // Pt Eta Phi of reconstructed electrons + positrons from LF (pi0,eta,etaprime,omega,phi,rho)
           if(hasHeavyAncestor(particle, particles))
                                           hTrack_ElePos_HF_Rec_Pt_Eta_Phi_afterPID[iPID_scenario]->Fill(track->PT,track->Eta,phiRec,weight);   // Pt Eta Phi of reconstructed electrons + positrons from HF
-
-          // // separate electrons & positrons originating from different light flavour (priamary), charm (cc) and buty (bb) decays
-          // if (!hasStrangeAncestor(particle, particles) && !hasHeavyAncestor(particle, particles)) {
-          //   hPrimaryM ->Fill(mother->PID);
-          //   hPrimaryGM->Fill(gmother->PID);
-          //                                  hPt_Eta_Phi_primary_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          //   if      (particle->PID == 11)  hPt_Eta_Phi_primary_Ele_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          //   else if (particle->PID == -11) hPt_Eta_Phi_primary_Pos_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          // }
-          // else {
-          //     if (hasCharmAncestor(particle, particles) || hasBeautyAncestor(particle, particles)){
-          //                                      hPt_Eta_Phi_hf_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          //       if      (particle->PID == 11)  hPt_Eta_Phi_hf_Ele_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          //       else if (particle->PID == -11) hPt_Eta_Phi_hf_Pos_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          //     }
-          //     if(isCharm(mPid) && !hasBeautyAncestor(particle, particles)){
-          //       hCharmGM->Fill(gmother->PID);
-          //                                      hPt_Eta_Phi_charm_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          //       if      (particle->PID == 11)  hPt_Eta_Phi_charm_Ele_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          //       else if (particle->PID == -11) hPt_Eta_Phi_charm_Pos_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          //     }
-          //     else if (isBeauty(mPid)) {
-          //     // else if (hasBeautyAncestor(particle, particles) && mPid > 500 && mPid < 600) {
-          //       hBeautyM->Fill(mother->PID);
-          //       hBeautyGM->Fill(gmother->PID);
-          //                                     hPt_Eta_Phi_beauty_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          //       if     (particle->PID == 11)  hPt_Eta_Phi_beauty_Ele_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          //       else if(particle->PID == -11) hPt_Eta_Phi_beauty_Pos_rec[iPID_scenario]->Fill(track->PT, track->Eta, phiRec);
-          //     }
-          //     else if (hasStrangeAncestor(particle, particles)) continue;
-          //     // else {
-          //     //   std::cout << particle->X << " " << particle->Y << " " << particle->Z << std::endl;
-          //     //   std::cout << " --- mother PDG     : " << mother->PID << std::endl;
-          //     //   std::cout << " --- grandmother PDG: " << gmother->PID << std::endl;
-          //     // }
-          // }
-
         }
 
         //apply pt cuts before filling vectors for pairing
-        if (!kineCuts(track, iPID_scenario)) continue;
-
-        // fill track vector
-        if (track->Charge < 0) vecNegTracks[iPID_scenario].push_back(track);       //  vector of all reconstructed negative tracks
-        else if (track->Charge > 0) vecPosTracks[iPID_scenario].push_back(track);  //  vector of all reconstructed positve tracks
-
-        if (particle->PID == 11 ) vecElectron[iPID_scenario].push_back(track);       // vector of reconstructed electrons
-        else if (particle->PID == -11 ) vecPositron[iPID_scenario].push_back(track); // vector of reconstructed positrons
-        // if (abs(particle->PID) == 11 ) {cout << "After kine cuts: track pt = " << track->PT << ", eta = " << track->Eta <<  endl;}
-
+        if (!kineCuts(track, iPID_scenario)) {
+            vecPosTracks[iPID_scenario].erase(vecPosTracks[iPID_scenario].begin()+itrack);
+            continue;  // end itrack loop
+        }
+        if (particle->PID == -11 ) vecPositron[iPID_scenario].push_back(track);       // vector of reconstructed positrons
       }
-
-
-
     }
-    vecPIDtracks.clear();
+
+
+
 
     // cout << "Number of tracks in vecNegTracks[0] = " <<  vecNegTracks[0].size() << endl;
 
@@ -1976,172 +1676,22 @@ void anaEEstudy(
   hTrackP_hasTOForRICH->Write();
   hTrackPt->Write();
   hTrackPt_hasTOForRICH->Write();
-  // hAllTracks_Rec_Pt_Eta_Phi->Write();
-  // hNegTrack_Rec_Pt_Eta_Phi->Write();
-  // hPosTrack_Rec_Pt_Eta_Phi->Write();
-  // hTrack_ElePos_Rec_Pt_Eta_Phi->Write();
-  // hTrack_Ele_Rec_Pt_Eta_Phi->Write();
-  // hTrack_Pos_Rec_Pt_Eta_Phi->Write();
-  // hTrack_Muon_Rec_Pt_Eta_Phi->Write();
-  // hTrack_Pion_Rec_Pt_Eta_Phi->Write();
-  // hTrack_Kaon_Rec_Pt_Eta_Phi->Write();
-  // hTrack_Proton_Rec_Pt_Eta_Phi->Write();
+
   hTrack_ElePos_Gen_Pt_Eta_Phi_beforeKineCuts->Write();
   hTrack_ElePos_GenSmeared_Pt_Eta_Phi_beforeKineCuts->Write();
-  // hTrack_All_Gen_Pt_Eta_Phi->Write();
-  // hTrack_ElePos_Gen_Pt_Eta_Phi->Write();
-  // hTrack_Muon_Gen_Pt_Eta_Phi->Write();
-  // hTrack_Pion_Gen_Pt_Eta_Phi->Write();
-  // hTrack_Kaon_Gen_Pt_Eta_Phi->Write();
-  // hTrack_Proton_Gen_Pt_Eta_Phi->Write();
-  // hTrack_Ele_Gen_Pt_Eta_Phi->Write();
-  // hTrack_Pos_Gen_Pt_Eta_Phi->Write();
-  // hTrack_ElePos_GenSmeared_Pt_Eta_Phi->Write();
-  // hTrack_Ele_GenSmeared_Pt_Eta_Phi->Write();
-  // hTrack_Pos_GenSmeared_Pt_Eta_Phi->Write();
-  // hPrimaryM->Write();
-  // hPrimaryGM->Write();
-  // hCharmMm->Write();
-  // hCharmMb->Write();
-  // hCharmGM->Write();
-  // hBeautyM->Write();
-  // hBeautyGM->Write();
+
   hBeforeSmearing_Pt_Eta_Phi_rec->Write();
   hAfterSmearing_Pt_Eta_Phi_rec->Write();
-  // hAfterKineCuts_Pt_Eta_Phi_rec->Write();
-  // hPt_Eta_Phi_primary_rec->Write();
-  // hPt_Eta_Phi_primary_Ele_rec->Write();
-  // hPt_Eta_Phi_primary_Pos_rec->Write();
-  // hPt_Eta_Phi_hf_rec->Write();
-  // hPt_Eta_Phi_hf_Ele_rec->Write();
-  // hPt_Eta_Phi_hf_Pos_rec->Write();
-  // hPt_Eta_Phi_charm_rec->Write();
-  // hPt_Eta_Phi_charm_Ele_rec->Write();
-  // hPt_Eta_Phi_charm_Pos_rec->Write();
-  // hPt_Eta_Phi_beauty_rec->Write();
-  // hPt_Eta_Phi_beauty_Ele_rec->Write();
-  // hPt_Eta_Phi_beauty_Pos_rec->Write();
-  // hPt_Eta_Phi_primary_gen->Write();
-  // hPt_Eta_Phi_primary_Ele_gen->Write();
-  // hPt_Eta_Phi_primary_Pos_gen->Write();
-  // hPt_Eta_Phi_hf_gen->Write();
-  // hPt_Eta_Phi_hf_Ele_gen->Write();
-  // hPt_Eta_Phi_hf_Pos_gen->Write();
-  // hPt_Eta_Phi_charm_gen->Write();
-  // hPt_Eta_Phi_charm_Ele_gen->Write();
-  // hPt_Eta_Phi_charm_Pos_gen->Write();
-  // hPt_Eta_Phi_beauty_gen->Write();
-  // hPt_Eta_Phi_beauty_Ele_gen->Write();
-  // hPt_Eta_Phi_beauty_Pos_gen->Write();
-
-  // hMPtDCA_ULS_gen->Write();
-  // hMPtDCA_ULS_gen_primary->Write();
-  // hMPtDCA_ULS_gen_heavy->Write();
-  // hMPtDCA_ULS_gen_charm->Write();
-  // hMPtDCA_ULS_gen_beauty->Write();
-  // hMPtDCA_LS_gen->Write();
-  // hMPtDCA_LS_gen_primary->Write();
-  // hMPtDCA_LS_gen_heavy->Write();
-  // hMPtDCA_LS_gen_charm->Write();
-  // hMPtDCA_LS_gen_beauty->Write();
-  // hMPtDCA_ULS_rec->Write();
-  // // hMPtDCA_ULS_rec_primary->Write();
-  // // hMPtDCA_ULS_rec_heavy->Write();
-  // // hMPtDCA_ULS_rec_charm->Write();
-  // // hMPtDCA_ULS_rec_beauty->Write();
-  // hMPtDCA_ULS_rec_MCpidEle->Write();
-  // // hMPtDCA_ULS_rec_MCpidEle_primary->Write();
-  // // hMPtDCA_ULS_rec_MCpidEle_heavy->Write();
-  // // hMPtDCA_ULS_rec_MCpidEle_charm->Write();
-  // // hMPtDCA_ULS_rec_MCpidEle_beauty->Write();
-  // hMPtDCA_LS_rec->Write();
-  // // hMPtDCA_LS_rec_primary->Write();
-  // // hMPtDCA_LS_rec_heavy->Write();
-  // // hMPtDCA_LS_rec_charm->Write();
-  // // hMPtDCA_LS_rec_beauty->Write();
-  // hMPtDCA_LS_rec_MCpidEle->Write();
-  // // hMPtDCA_LS_rec_MCpidEle_primary->Write();
-  // // hMPtDCA_LS_rec_MCpidEle_heavy->Write();
-  // // hMPtDCA_LS_rec_MCpidEle_charm->Write();
-  // // hMPtDCA_LS_rec_MCpidEle_beauty->Write();
-
-  hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID->Write();
-  hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID->Write();
-  hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID->Write();
-
-  // fout->cd("generated/");
-  // fout->mkdir("generated/LS");
-  // fout->cd("generated/LS");
-  // fout->cd();
-  // fout->mkdir("reconstructed/");
-  // fout->cd("reconstructed/");
-  // fout->mkdir("reconstructed/ULS");
-  // fout->cd("reconstructed/ULS");
-
 
   hM_Pt_sig_gen->Write();
 
-  hInnerBetaP_beforeSmearing->Write();
-  hInnerBetaP_afterSmearing->Write();
-  if(bPlotPIDhists){
-    if(bUseiTOF){
-      for (int i = 0; i < 5; ++i) hNsigmaP_innerTOF[i]->Write();
-      for (int i = 0; i < 5; ++i) hNsigmaP_innerTOF_trueElec[i]->Write();
-      for (int i = 0; i < 5; ++i) hNsigmaP_innerTOF_trueMuon[i]->Write();
-      for (int i = 0; i < 5; ++i) hNsigmaP_innerTOF_truePion[i]->Write();
-      for (int i = 0; i < 5; ++i) hNsigmaP_innerTOF_trueKaon[i]->Write();
-      for (int i = 0; i < 5; ++i) hNsigmaP_innerTOF_trueProton[i]->Write();
-    }
-
-    hBetaP_beforeSmearing->Write();
-    hBetaP_afterSmearing->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_TOF[i]->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_TOF_trueElec[i]->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_TOF_trueMuon[i]->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_TOF_truePion[i]->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_TOF_trueKaon[i]->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_TOF_trueProton[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_TOF[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_TOF_trueElec[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_TOF_trueMuon[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_TOF_truePion[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_TOF_trueKaon[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_TOF_trueProton[i]->Write();
-
-
-    hCherenkovAngleP_beforeSmearing->Write();
-    hCherenkovAngleP_afterSmearing->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_RICH[i]->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_RICH_trueElec[i]->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_RICH_trueMuon[i]->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_RICH_truePion[i]->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_RICH_trueKaon[i]->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaP_RICH_trueProton[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_RICH[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_RICH_trueElec[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_RICH_trueMuon[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_RICH_truePion[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_RICH_trueKaon[i]->Write();
-    // for (int i = 0; i < 5; ++i) hNsigmaP_afterPIDcuts_RICH_trueProton[i]->Write();
-    for (int i = 0; i < 5; ++i) hNsigmaBeta_RICH[i]->Write();
-  }
-
-
-  // fout->cd("reconstructed/");
-
-  // fout->mkdir("reconstructed/LS");
-  // fout->cd("reconstructed/LS");
   fout->Close();
-
-
 
   // stop watch
   watch->Stop();
   watch->Print();
 
 }
-
-
 
 
 
@@ -2237,33 +1787,6 @@ void dileptonPairingRec(std::vector<Track *> vec_track_neg,std::vector<Track *> 
       if((!pairULS && MCpidEle) && (std::find(vecLFpdgs.begin(), vecLFpdgs.end(), m1Pid) != vecLFpdgs.end()) && (std::find(vecLFpdgs.begin(), vecLFpdgs.end(), m2Pid) != vecLFpdgs.end()) ) hMPtDCA_LS_rec_lfTOee_selectPDG[iSce]->Fill(LV.Mag(),LV.Pt(),dca,weight_neg*weight_pos);
       // if((!pairULS && MCpidEle) && ( ((abs(m1Pid) == 111 && abs(m2Pid) == 111) || (abs(m1Pid) == 221 && abs(m2Pid) == 221) || (abs(m1Pid) == 331 && abs(m2Pid) == 331) || (abs(m1Pid) == 223 && abs(m2Pid) == 223) || (abs(m1Pid) == 333 && abs(m2Pid) == 333) || (abs(m1Pid) == 113 && abs(m2Pid) == 113))) ) hMPtDCA_LS_rec_lfTOee_selectPDG[iSce]->Fill(LV.Mag(),LV.Pt(),dca,weight_neg*weight_pos);
 
-
-      // if (mother1 == mother2 && !hasHeavyAncestor(particle1, particles) && !hasStrangeAncestor(particle1, particles)){ // same mother and neutral LF particle, pion or eta
-      //   if(pairULS && !MCpidEle)  hMPtDCA_ULS_rec_primary[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS && !MCpidEle) hMPtDCA_LS_rec_primary[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(pairULS && MCpidEle)  hMPtDCA_ULS_rec_MCpidEle_primary[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS && MCpidEle) hMPtDCA_LS_rec_MCpidEle_primary[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      // }
-      // if (mother1 != mother2 && hasHeavyAncestor(particle1, particles) && hasHeavyAncestor(particle2, particles)){
-      //   if(pairULS && !MCpidEle)  hMPtDCA_ULS_rec_heavy[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS && !MCpidEle) hMPtDCA_LS_rec_heavy[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(pairULS && MCpidEle)  hMPtDCA_ULS_rec_MCpidEle_heavy[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS && MCpidEle) hMPtDCA_LS_rec_MCpidEle_heavy[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      // }
-      // if ( isCharm(m1Pid) && isCharm(m2Pid) && !hasBeautyAncestor(particle1, particles) && !hasBeautyAncestor(particle2, particles) ){
-      // // if(mother1 != mother2  && hasCharmAncestor(particle1, particles) && hasCharmAncestor(particle2, particles))
-      //   if(pairULS && !MCpidEle)  hMPtDCA_ULS_rec_charm[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS && !MCpidEle) hMPtDCA_LS_rec_charm[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(pairULS && MCpidEle)  hMPtDCA_ULS_rec_MCpidEle_charm[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS && MCpidEle) hMPtDCA_LS_rec_MCpidEle_charm[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      // }
-      // if( isBeauty(m1Pid) && isBeauty(m2Pid) ){
-      // // if(mother1 != mother2 && hasBeautyAncestor(particle1, particles) && hasBeautyAncestor(particle2, particles) )
-      //   if(pairULS && !MCpidEle)  hMPtDCA_ULS_rec_beauty[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS && !MCpidEle) hMPtDCA_LS_rec_beauty[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(pairULS && MCpidEle)  hMPtDCA_ULS_rec_MCpidEle_beauty[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS && MCpidEle) hMPtDCA_LS_rec_MCpidEle_beauty[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      // }
     }
   }
 }
@@ -2335,74 +1858,78 @@ void dileptonPairingGen(std::vector<GenParticle *> vec_track_neg,std::vector<Gen
       if(pairULS)  hMPtDCA_ULS_gen[iSce]->Fill(LV.Mag(),LV.Pt(),dca,weight_neg*weight_pos);
       if(!pairULS) hMPtDCA_LS_gen[iSce]->Fill(LV.Mag(),LV.Pt(),dca,weight_neg*weight_pos);
 
-      // if (mother1 == mother2 && !hasHeavyAncestor(particle1, particles) && !hasStrangeAncestor(particle1, particles)) // same mother and neutral LF particle, pion or eta
-      // {
-      //   if(pairULS)  hMPtDCA_ULS_gen_primary[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS) hMPtDCA_LS_gen_primary[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      // }
-      // if (mother1 != mother2 && hasHeavyAncestor(particle1, particles) && hasHeavyAncestor(particle2, particles))
-      // {
-      //   if(pairULS)  hMPtDCA_ULS_gen_heavy[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS) hMPtDCA_LS_gen_heavy[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      // }
-      // if ( isCharm(m1Pid) && isCharm(m2Pid) && !hasBeautyAncestor(particle1, particles) && !hasBeautyAncestor(particle2, particles) )
-      // // if(mother1 != mother2  && hasCharmAncestor(particle1, particles) && hasCharmAncestor(particle2, particles))
-      // {
-      //   if(pairULS)  hMPtDCA_ULS_gen_charm[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS) hMPtDCA_LS_gen_charm[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      // }
-      // if( isBeauty(m1Pid) && isBeauty(m2Pid) )
-      // // if(mother1 != mother2 && hasBeautyAncestor(particle1, particles) && hasBeautyAncestor(particle2, particles) )
-      // {
-      //   if(pairULS)  hMPtDCA_ULS_gen_beauty[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      //   if(!pairULS) hMPtDCA_LS_gen_beauty[iSce]->Fill(LV.Mag(),LV.Pt(),dca);
-      // }
     }
   }
 }
 
 
-// // function to ULS or LS pair reconstructed particles
-// void PreFilter(std::vector<Track *> vec_track_neg,std::vector<Track *> vec_track_pos,TClonesArray *particles){
-//   // pairing reconstructed ULS or LS pairs
-//   double vec_track_neg_size = vec_track_neg.size();
-//   double vec_track_pos_size = vec_track_pos.size();
-//   int    iPos_start = 0;
-//   int    iNeg_end = vec_track_neg_size;
-//   TLorentzVector LV1,LV2,LV;
-//   double dca= 0. ,dca1 = 0.,dca2 = 0.;
-//
-//   for (int iEle = 0; iEle < iNeg_end; iEle++){
-//     auto track1 = (Track *) vec_track_neg.at(iEle);
-//     auto particle1 = (GenParticle *)track1->Particle.GetObject();
-//     auto imother1 = particle1->M1;
-//     auto mother1 = imother1 != -1 ? (GenParticle *)particles->At(imother1) : (GenParticle *)nullptr;
-//     auto m1Pid = mother1->PID;
-//     LV1.SetPtEtaPhiM(track1->PT,track1->Eta,track1->Phi,eMass);
-//
-//     for (auto iPos = iPos_start; iPos < vec_track_pos_size; iPos++){
-//       auto track2 = (Track *) vec_track_pos.at(iPos);
-//       auto particle2 = (GenParticle *)track2->Particle.GetObject();
-//       auto imother2 = particle2->M1;
-//       auto mother2 = imother2 != -1 ? (GenParticle *)particles->At(imother2) : (GenParticle *)nullptr;
-//       auto m2Pid = mother2->PID;
-//       LV2.SetPtEtaPhiM(track2->PT,track2->Eta,track2->Phi,eMass);
-//       LV = LV1 + LV2;
-//
-//       dca1 = (track1->D0/track1->ErrorD0);
-//       dca2 = (track2->D0/track2->ErrorD0);
-//       dca = sqrt((dca1*dca1 + dca2*dca2) / 2);
-//
-//       if( (LV->M < 0.139) && (dca < 2.) ) {
-//         // remove tracks from vectors
-//         vec_track_neg -> erase(vec_track_neg -> begin()+iEle);
-//         vec_track_pos -> erase(vec_track_pos -> begin()+iPos);
-//         iEle--;
-//         iPos--;
-//         break;  // end iPos loop
-//       }
-//
-//
-//     }
-//   }
-// }
+
+// Apply a prefilter on invariant mass and opening angle
+void PreFilter(std::vector<Track *>* vec_track_neg,std::vector<Track *>* vec_track_pos,TClonesArray *particles, Int_t iPIDscenario, TH1* hBeforePF, TH1* hAfterPF){
+  // pairing reconstructed ULS or LS pairs
+  std::vector<Int_t> vecDelPos, vecDelEle;
+  TLorentzVector LV1,LV2,LV;
+  // double dca= 0. ,dca1 = 0.,dca2 = 0.;
+
+  for (int iEle = 0; iEle < vec_track_neg->size() ; iEle++){
+    auto track1 = (Track *) vec_track_neg->at(iEle);
+    auto particle1 = (GenParticle *)track1->Particle.GetObject();
+    auto imother1 = particle1->M1;
+    auto mother1 = imother1 != -1 ? (GenParticle *)particles->At(imother1) : (GenParticle *)nullptr;
+    auto m1Pid = mother1->PID;
+    LV1.SetPtEtaPhiM(track1->PT,track1->Eta,track1->Phi,eMass);
+
+    if( LV1.Pt() < pf_pt_cut[iPIDscenario] ) {
+      vec_track_neg->erase(vec_track_neg->begin()+iEle);
+      iEle--;
+      continue;
+    }
+
+    for (auto iPos = 0; iPos < vec_track_pos->size(); iPos++){
+      auto track2 = (Track *) vec_track_pos->at(iPos);
+      auto particle2 = (GenParticle *)track2->Particle.GetObject();
+      auto imother2 = particle2->M1;
+      auto mother2 = imother2 != -1 ? (GenParticle *)particles->At(imother2) : (GenParticle *)nullptr;
+      auto m2Pid = mother2->PID;
+      LV2.SetPtEtaPhiM(track2->PT,track2->Eta,track2->Phi,eMass);
+      LV = LV1 + LV2;
+      double opAngle = fabs(TVector2::Phi_mpi_pi(LV1.Angle(LV2.Vect())));
+      if(TMath::IsNaN(opAngle)){
+          continue;
+      }
+
+      if( (imother1 == imother2) && (abs(m1Pid)==111) ) hBeforePF->Fill(LV.M(), opAngle);
+
+      // apply prefilter pt cut from the corresponding PIDscenario
+      if( LV2.Pt() < pf_pt_cut[iPIDscenario] ) {
+        vec_track_pos->erase(vec_track_pos->begin()+iPos);
+        iPos--;
+        continue;
+      }
+
+
+      if( !((LV.M() < pf_mass_cut[iPIDscenario]) && (opAngle < pf_opAngle_cut[iPIDscenario])) && ((imother1 == imother2) && (abs(m1Pid)==111)) ) hAfterPF ->Fill(LV.M(), opAngle);
+
+      if( (LV.M() < pf_mass_cut[iPIDscenario]) && (opAngle < pf_opAngle_cut[iPIDscenario]) ) {
+        vecDelEle.push_back(iEle);
+        vecDelPos.push_back(iPos);
+      }
+    }
+  }
+
+  std::sort(vecDelEle.begin(), vecDelEle.end());
+  std::sort(vecDelPos.begin(), vecDelPos.end());
+
+  vecDelEle.erase(std::unique(vecDelEle.begin(), vecDelEle.end()), vecDelEle.end());
+  vecDelPos.erase(std::unique(vecDelPos.begin(), vecDelPos.end()), vecDelPos.end());
+
+  for (int i = vecDelEle.size()-1; i >= 0; i--){
+    // erase element at position stored in index vector vecDelEle
+    vec_track_neg->erase(vec_track_neg->begin() + vecDelEle.at(i));
+  }
+  for (int j = vecDelPos.size()-1; j >= 0; j--){
+    // erase element at position stored in index vector vecDelPos
+    vec_track_pos->erase(vec_track_pos->begin() + vecDelPos.at(j));
+  }
+
+}

--- a/efficiency/macros/anaPlots.cxx
+++ b/efficiency/macros/anaPlots.cxx
@@ -19,13 +19,18 @@ bool bwriteFileLFHFweights = kFALSE;
 bool bGenerateBackground = kTRUE;
 
 int ith_PIDscenario = 1;
+int nPIDscenarios = 6;
 // TString strPIDscenario[] = {"TOF", "TOF+RICH (3#sigma_{#pi}^{RICH} rej)", "TOF+RICH (3.5#sigma_{#pi}^{RICH} rej)", "TOF+RICH (4#sigma_{#pi}^{RICH} rej)"};
 // TString strPIDscenario[] = {"0.08 < #it{p}_{T,e}, TOF only", "0.0 < #it{p}_{T,e}, TOF only"};
 // TString strPIDscenario[] = {"0.04 < #it{p}_{T,e}, iTOF only", "0.0 < #it{p}_{T,e}, iTOF only"};
 // TString strPIDscenario[] = {"0.2 < #it{p}_{T,e}, TOF", "0.2 < #it{p}_{T,e}, RICH", "0.2 < #it{p}_{T,e}, TOF+RICH"};
-// TString strPIDscenario[] = {"0.2 < #it{p}_{T,e}, TOF+RICH"};
-TString strPIDscenario[] = {"0.3 < #it{p}_{T,e}, TOF+RICH"};
+TString strPIDscenario[] = {"0.2 < #it{p}_{T,e}, TOF+RICH"};
+// TString strPIDscenario[] = {"0.08 < #it{p}_{T,e}, iTOF only"};
 // TString strPIDscenario[] = {"TOF+RICH (4#sigma_{#pi} 0.2<pte)", "TOF+RICH (4#sigma_{#pi} 0.08<pte)"};
+
+Bool_t DCAcut = true;
+Double_t etaCutsVec[] = {0.8,0.8,0.8,0.8,0.8,0.8};
+// Double_t etaCutsVec[] = {0.8,1.25,1.75,2.5,3.0,4.0};
 
 std::vector<Double_t> vec_proj_bin_p = {0.0, 0.3, 0.5, 0.7, 1.0, 2.0, 4.0, 10.0};
 std::vector<Double_t> vec_proj_bin_pt = {0.0, 0.3, 0.5, 0.7, 1.0, 2.0, 4.0, 10.0};
@@ -33,11 +38,15 @@ std::vector<Double_t> vec_proj_bin_mass = {0.0, 3.0}; // Intervalls for projecti
 
 // Double_t pt_bin_proj[]  = {0.0,0.02,0.04,0.06,0.08,0.1,0.12,0.14,0.16,0.18,0.2,0.25,0.3,0.35,0.4,0.45,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.75,2.0,2.25,2.5,2.75,3.0,3.5,4.0};
 // Double_t pt_bin_proj[]  = {0.0,0.02,0.04,0.06,0.08,0.1,0.12,0.14,0.16,0.18,0.2,0.25,0.3,0.35,0.4,0.45,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.75,2.0,2.25,2.5,4.0};
-Double_t pt_bin_proj[]  = {0.0,0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09,0.1,0.12,0.14,0.16,0.18,0.2,0.22,0.24,0.26,0.28,0.3,0.35,0.4,0.45,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.75,2.0,2.25,2.5,2.75,3.0,3.5,4.0};
-Double_t pt_bin_proj_10[]  = {0.0,0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09,0.1,0.12,0.14,0.16,0.18,0.2,0.22,0.24,0.26,0.28,0.3,0.35,0.4,0.45,0.5,0.55,0.6,0.65,0.7,0.75,0.8,0.85,0.9,0.95,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2.0,2.2,2.4,2.6,2.8,3.0,3.2,3.4,3.6,3.8,4.0,4.5,5.0,5.5,6.0,6.5,7.0,8.0,9.0,10.};
+// Double_t pt_bin_proj[]     = {0.0,0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09,0.1,0.12,0.14,0.16,0.18,0.2,0.22,0.24,0.26,0.28,0.3,0.35,0.4,0.45,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.75,2.0,2.25,2.5,2.75,3.0,3.5,4.0};
+// Double_t pt_bin_proj_10[]  = {0.0,0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09,0.1,0.12,0.14,0.16,0.18,0.2,0.22,0.24,0.26,0.28,0.3,0.35,0.4,0.45,0.5,0.55,0.6,0.65,0.7,0.75,0.8,0.85,0.9,0.95,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2.0,2.2,2.4,2.6,2.8,3.0,3.2,3.4,3.6,3.8,4.0,4.5,5.0,5.5,6.0,6.5,7.0,8.0,9.0,10.};
+// Double_t pte_bin_2D[]      = {0.0,0.02,0.04,0.06,0.08,0.1,0.12,0.14,0.16,0.18,0.2,0.22,0.24,0.26,0.28,0.3,0.35,0.4,0.45,0.5,0.55,0.6,0.65,0.7,0.75,0.8,0.85,0.9,0.95,1.,1.2,1.4,1.6,1.8,2.,2.2,2.4,2.6,2.8,3.,3.5,4.,5.,6.,7.,8.,9.,10.};
+// Double_t pte_bin_2D[]      = {0.0,0.02,0.04,0.06,0.08,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.,1.2,1.4,1.6,1.8,2.,2.2,2.4,2.6,2.8,3.,3.5,4.,5.,6.,7.,8.,9.,10.};
+Double_t pte_bin_2D[]      = {0.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.,1.2,1.4,1.6,1.8,2.,2.2,2.4,2.6,2.8,3.,3.5,4.,5.,6.,7.,8.,9.,10.};
 // Double_t pt_bin_proj[]  = {0.0,0.1,0.5,1.,4};
-Int_t nbinspt_proj  = sizeof(pt_bin_proj)/sizeof(*pt_bin_proj) -1;
-Int_t nbinspt_proj_10  = sizeof(pt_bin_proj_10)/sizeof(*pt_bin_proj_10) -1;
+// Int_t nbinspt_proj  = sizeof(pt_bin_proj)/sizeof(*pt_bin_proj) -1;
+// Int_t nbinspt_proj_10  = sizeof(pt_bin_proj_10)/sizeof(*pt_bin_proj_10) -1;
+Int_t nbinspt_proj_2D  = sizeof(pte_bin_2D)/sizeof(*pte_bin_2D) -1;
 
 void makeHistNice(TH1* h, int color){
   h->SetTitle("");
@@ -173,6 +182,8 @@ TH1F *RatioToTheoryy(TH1 *ffit, TH1 *ginput) {
 void anaPlots(TString inputFile)
 {
   TFile *fIn  = TFile::Open(inputFile.Data());
+  for (Int_t ith_PIDscenario = 1; ith_PIDscenario <= nPIDscenarios; ith_PIDscenario++) {
+
 
   // select which PID cenario (written in the input file) should be analyzed
   TString pathRecPIDScenario = Form("reconstructed/PIDscenario_%i", ith_PIDscenario);
@@ -182,9 +193,9 @@ void anaPlots(TString inputFile)
   TString collSystem;
   Bool_t findBField;
   Bool_t findCollSystem;
-  findBField = inputFile.Contains("B=0.2");
+  findBField = inputFile.Contains("B=2kG");
   if (findBField) BField = 0.2;
-  findBField = inputFile.Contains("B=0.5");
+  findBField = inputFile.Contains("B=5kG");
   if (findBField) BField = 0.5;
   findBField = inputFile.Contains("B=20kG");
   if (findBField) BField = 2.0;
@@ -329,49 +340,22 @@ void anaPlots(TString inputFile)
     }
 
 
-  // read generated ULS histos
-  // fIn->cd("generated/ULS");
   // Track histograms
-
-  // TH3F* hRec_TrackPtEtaPhi_primary = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_primary_rec");
-  // TH3F* hRecEle_TrackPtEtaPhi_primary = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_primary_Ele_rec");
-  // TH3F* hRecPos_TrackPtEtaPhi_primary = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_primary_Pos_rec");
-  // TH3F* hRec_TrackPtEtaPhi_hf = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_hf_rec");
-  // TH3F* hRecEle_TrackPtEtaPhi_hf = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_hf_Ele_rec");
-  // TH3F* hRecPos_TrackPtEtaPhi_hf = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_hf_Pos_rec");
-  // TH3F* hRec_TrackPtEtaPhi_cc = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_charm_rec");
-  // TH3F* hRecEle_TrackPtEtaPhi_cc = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_charm_Ele_rec");
-  // TH3F* hRecPos_TrackPtEtaPhi_cc = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_charm_Pos_rec");
-  // TH3F* hRec_TrackPtEtaPhi_bb = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_beauty_rec");
-  // TH3F* hRecEle_TrackPtEtaPhi_bb = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_beauty_Ele_rec");
-  // TH3F* hRecPos_TrackPtEtaPhi_bb = (TH3F*) fIn->cd(pathRecPIDScenario)->Get("hPt_Eta_Phi_beauty_Pos_rec");
-
-  // TH3F* hGen_TrackPtEtaPhi_primary = (TH3F*) fIn->Get("hPt_Eta_Phi_primary_gen");
-  // TH3F* hGenEle_TrackPtEtaPhi_primary = (TH3F*) fIn->Get("hPt_Eta_Phi_primary_Ele_gen");
-  // TH3F* hGenPos_TrackPtEtaPhi_primary = (TH3F*) fIn->Get("hPt_Eta_Phi_primary_Pos_gen");
-  // TH3F* hGen_TrackPtEtaPhi_hf = (TH3F*) fIn->Get("hPt_Eta_Phi_hf_gen");
-  // TH3F* hGenEle_TrackPtEtaPhi_hf = (TH3F*) fIn->Get("hPt_Eta_Phi_hf_Ele_gen");
-  // TH3F* hGenPos_TrackPtEtaPhi_hf = (TH3F*) fIn->Get("hPt_Eta_Phi_hf_Pos_gen");
-  // TH3F* hGen_TrackPtEtaPhi_cc = (TH3F*) fIn->Get("hPt_Eta_Phi_charm_gen");
-  // TH3F* hGenEle_TrackPtEtaPhi_cc = (TH3F*) fIn->Get("hPt_Eta_Phi_charm_Ele_gen");
-  // TH3F* hGenPos_TrackPtEtaPhi_cc = (TH3F*) fIn->Get("hPt_Eta_Phi_charm_Pos_gen");
-  // TH3F* hGen_TrackPtEtaPhi_bb = (TH3F*) fIn->Get("hPt_Eta_Phi_beauty_gen");
-  // TH3F* hGenEle_TrackPtEtaPhi_bb = (TH3F*) fIn->Get("hPt_Eta_Phi_beauty_Ele_gen");
-  // TH3F* hGenPos_TrackPtEtaPhi_bb = (TH3F*) fIn->Get("hPt_Eta_Phi_beauty_Pos_gen");
 
   TH3F* hRec_Track_Pt_Eta_Phi_BeforeSmearing = (TH3F*) fIn->Get("hBeforeSmearing_Pt_Eta_Phi_rec");
   TH3F* hRec_Track_Pt_Eta_Phi_AfterSmearing = (TH3F*) fIn->Get("hAfterSmearing_Pt_Eta_Phi_rec");
 
   TH3F* hRec_Track_Pt_Eta_Phi_AfterKineCuts = (TH3F*) fIn->Get(Form("%s/hAfterKineCuts_Pt_Eta_Phi_rec_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
   TH3F* hRec_Track_ElePos_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_ElePos_Rec_Pt_Eta_Phi_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
-  TH3F* hRec_Track_ElePos_Pi0_Pt_Eta_Phi_beforePID = (TH3F*) fIn->Get("hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID");
-  TH3F* hRec_Track_ElePos_LF_Pt_Eta_Phi_beforePID = (TH3F*) fIn->Get("hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID");
-  TH3F* hRec_Track_ElePos_HF_Pt_Eta_Phi_beforePID = (TH3F*) fIn->Get("hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID");
+  // TH3F* hRec_Track_ElePos_Pi0_Pt_Eta_Phi_beforePID = (TH3F*) fIn->Get("hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID");
+  // TH3F* hRec_Track_ElePos_LF_Pt_Eta_Phi_beforePID = (TH3F*) fIn->Get("hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID");
+  // TH3F* hRec_Track_ElePos_HF_Pt_Eta_Phi_beforePID = (TH3F*) fIn->Get("hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID");
+  TH3F* hRec_Track_ElePos_Pi0_Pt_Eta_Phi_beforePID = (TH3F*) fIn->Get(Form("%s/hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_beforePID_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
+  TH3F* hRec_Track_ElePos_LF_Pt_Eta_Phi_beforePID = (TH3F*) fIn->Get(Form("%s/hTrack_ElePos_LF_Rec_Pt_Eta_Phi_beforePID_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
+  TH3F* hRec_Track_ElePos_HF_Pt_Eta_Phi_beforePID = (TH3F*) fIn->Get(Form("%s/hTrack_ElePos_HF_Rec_Pt_Eta_Phi_beforePID_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
   TH3F* hRec_Track_ElePos_Pi0_Pt_Eta_Phi_afterPID = (TH3F*) fIn->Get(Form("%s/hTrack_ElePos_Pi0_Rec_Pt_Eta_Phi_afterPID_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
   TH3F* hRec_Track_ElePos_LF_Pt_Eta_Phi_afterPID = (TH3F*) fIn->Get(Form("%s/hTrack_ElePos_LF_Rec_Pt_Eta_Phi_afterPID_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
   TH3F* hRec_Track_ElePos_HF_Pt_Eta_Phi_afterPID = (TH3F*) fIn->Get(Form("%s/hTrack_ElePos_HF_Rec_Pt_Eta_Phi_afterPID_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
-  TH3F* hRec_Track_Ele_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Ele_Rec_Pt_Eta_Phi_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
-  TH3F* hRec_Track_Pos_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Pos_Rec_Pt_Eta_Phi_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
   TH3F* hRec_AllTrack_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hAllTracks_Rec_Pt_Eta_Phi_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
   TH3F* hRec_NegTrack_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hNegTrack_Rec_Pt_Eta_Phi_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
   TH3F* hRec_PosTrack_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hPosTrack_Rec_Pt_Eta_Phi_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
@@ -385,32 +369,23 @@ void anaPlots(TString inputFile)
   TH3F* hGen_Track_ElePos_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_ElePos_Gen_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
   TH3F* hGen_Track_Muon_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Muon_Gen_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
   TH3F* hGen_Track_Pion_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Pion_Gen_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  TH3F* hGen_Track_Kaon_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Kaon_Gen_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  TH3F* hGen_Track_Proton_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Proton_Gen_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  TH3F* hGen_Track_Ele_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Ele_Gen_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  TH3F* hGen_Track_Pos_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Pos_Gen_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
   TH3F* hGen_Track_Pion_Pt_Rap_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Pion_Gen_Pt_Rap_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
+  // TH3F* hGen_Track_Kaon_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Kaon_Gen_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
+  // TH3F* hGen_Track_Proton_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Proton_Gen_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
+  // TH3F* hGen_Track_ElePos_LF_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_ElePos_LF_Gen_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
   TH3F* hGen_Track_ElePos_HF_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_ElePos_HF_Gen_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
 
   // TH3F* hGenSmeared_Track_ElePos_Pt_Eta_Phi_beforeKineCuts = (TH3F*) fIn->Get("hTrack_ElePos_GenSmeared_Pt_Eta_Phi_beforeKineCuts");
   TH3F* hGenSmeared_Track_ElePos_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_ElePos_GenSmeared_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  TH3F* hGenSmeared_Track_Ele_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Ele_GenSmeared_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  TH3F* hGenSmeared_Track_Pos_Pt_Eta_Phi = (TH3F*) fIn->Get(Form("%s/hTrack_Pos_GenSmeared_Pt_Eta_Phi_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
 
-  TH1F* hRec_Track_Pt_hasPS = (TH1F*) fIn->Get(Form("%s/hTrack_ElePos_Rec_Pt_hasPS_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
+  // TH1F* hTracks_ElePos_Gen_inPFvector_Pt = (TH1F*) fIn->Get(Form("%s/hTracks_ElePos_Gen_inPFvector_Pt_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
+  // TH1F* hTracks_ElePos_Rec_inPFvector_Pt = (TH1F*) fIn->Get(Form("%s/hTracks_ElePos_Rec_inPFvector_Pt_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
 
+  // TH2F* hMeeOpAngle_RecULS_bPF = (TH2F*) fIn->Get(Form("%s/hMeeOpAngle_RecULS_bPF_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
+  // TH2F* hMeeOpAngle_RecULS_aPF = (TH2F*) fIn->Get(Form("%s/hMeeOpAngle_RecULS_aPF_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
 
+  TF1* funcPSparam = new TF1("funcPSparam","0.8*(1.-exp(-1.6*(x-0.05)))",0,4);
 
-  // TH3F* hRec_Track_Pt_Eta_Phi_EtaCut1 = (TH3F*) fIn->Get("hPt_Eta_Phi_rec_Eta_Cut_1");
-  // TH3F* hRec_Track_Pt_Eta_Phi_EtaCut2 = (TH3F*) fIn->Get("hPt_Eta_Phi_rec_Eta_Cut_2");
-  // TH3F* hRec_Track_Pt_Eta_Phi_EtaCut3 = (TH3F*) fIn->Get("hPt_Eta_Phi_rec_Eta_Cut_3");
-  // TH3F* hRec_Track_Pt_Eta_Phi_EtaCut4 = (TH3F*) fIn->Get("hPt_Eta_Phi_rec_Eta_Cut_4");
-  // TH3F* hRec_Track_Pt_Eta_Phi_EtaCut5 = (TH3F*) fIn->Get("hPt_Eta_Phi_rec_Eta_Cut_5");
-  // TH3F* hRec_Track_Pt_Eta_Phi_EtaCut6 = (TH3F*) fIn->Get("hPt_Eta_Phi_rec_Eta_Cut_6");
-  // TH3F* hRec_Track_Pt_Eta_Phi_EtaCut7 = (TH3F*) fIn->Get("hPt_Eta_Phi_rec_Eta_Cut_7");
-  // TH3F* hRec_Track_Pt_Eta_Phi_EtaCut8 = (TH3F*) fIn->Get("hPt_Eta_Phi_rec_Eta_Cut_8");
-  // TH3F* hRec_Track_Pt_Eta_Phi_EtaCut9 = (TH3F*) fIn->Get("hPt_Eta_Phi_rec_Eta_Cut_9");
-  // TH3F* hRec_Track_Pt_Eta_Phi_EtaCut10 = (TH3F*) fIn->Get("hPt_Eta_Phi_rec_Eta_Cut_10");
 
   std::vector<TH2F*> vecTOF_PIDplots;
   std::vector<TH2F*> vecRICH_PIDplots;
@@ -422,26 +397,19 @@ void anaPlots(TString inputFile)
   TH2 *hNsigmaP_TOF_trueElec[5];
   TH2 *hNsigmaP_TOF_trueMuon[5];
   TH2 *hNsigmaP_TOF_truePion[5];
-  TH2 *hNsigmaP_TOF_trueKaon[5];
-  TH2 *hNsigmaP_TOF_trueProton[5];
   TH2 *hNsigmaP_afterPIDcuts_TOF_trueElec[5];
   TH2 *hNsigmaP_afterPIDcuts_TOF_trueMuon[5];
   TH2 *hNsigmaP_afterPIDcuts_TOF_truePion[5];
-  TH2 *hNsigmaP_afterPIDcuts_TOF_trueKaon[5];
-  TH2 *hNsigmaP_afterPIDcuts_TOF_trueProton[5];
 
   TH2 *hNsigmaP_RICH[5];
   TH2 *hNsigmaP_RICH_trueElec[5];
   TH2 *hNsigmaP_RICH_trueMuon[5];
   TH2 *hNsigmaP_RICH_truePion[5];
-  TH2 *hNsigmaP_RICH_trueKaon[5];
-  TH2 *hNsigmaP_RICH_trueProton[5];
   TH2 *hNsigmaP_afterPIDcuts_RICH[5];
   TH2 *hNsigmaP_afterPIDcuts_RICH_trueElec[5];
   TH2 *hNsigmaP_afterPIDcuts_RICH_trueMuon[5];
   TH2 *hNsigmaP_afterPIDcuts_RICH_truePion[5];
-  TH2 *hNsigmaP_afterPIDcuts_RICH_trueKaon[5];
-  TH2 *hNsigmaP_afterPIDcuts_RICH_trueProton[5];
+
 
   std::vector<TH2F*> vecHistosNSigma_afterCuts;
   std::vector<TH2F*> vecHistosNSigma;
@@ -486,14 +454,10 @@ if (bPlotPIDhistograms) {
     hNsigmaP_TOF_trueElec[i] = (TH2F*) fIn->Get(Form("hNsigmaP_%s_TOF_trueElec", pname[i]));
     hNsigmaP_TOF_trueMuon[i] = (TH2F*) fIn->Get(Form("hNsigmaP_%s_TOF_trueMuon", pname[i]));
     hNsigmaP_TOF_truePion[i] = (TH2F*) fIn->Get(Form("hNsigmaP_%s_TOF_truePion", pname[i]));
-    hNsigmaP_TOF_trueKaon[i] = (TH2F*) fIn->Get(Form("hNsigmaP_%s_TOF_trueKaon", pname[i]));
-    hNsigmaP_TOF_trueProton[i] = (TH2F*) fIn->Get(Form("hNsigmaP_%s_TOF_trueProton", pname[i]));
     // hNsigmaP_afterPIDcuts_TOF[i] = (TH2F*) fIn->Get(Form("hNsigmaP_%s_afterPIDcuts_TOF", pname[i]));
     hNsigmaP_afterPIDcuts_TOF_trueElec[i] = (TH2F*) fIn->Get(Form("%s/hNsigmaP_%s_afterPIDcuts_TOF_trueElec_sce%i", pathRecPIDScenario.Data(),pname[i],ith_PIDscenario));
     hNsigmaP_afterPIDcuts_TOF_trueMuon[i] = (TH2F*) fIn->Get(Form("%s/hNsigmaP_%s_afterPIDcuts_TOF_trueMuon_sce%i", pathRecPIDScenario.Data(),pname[i],ith_PIDscenario));
     hNsigmaP_afterPIDcuts_TOF_truePion[i] = (TH2F*) fIn->Get(Form("%s/hNsigmaP_%s_afterPIDcuts_TOF_truePion_sce%i", pathRecPIDScenario.Data(),pname[i],ith_PIDscenario));
-    hNsigmaP_afterPIDcuts_TOF_trueKaon[i] = (TH2F*) fIn->Get(Form("%s/hNsigmaP_%s_afterPIDcuts_TOF_trueKaon_sce%i", pathRecPIDScenario.Data(),pname[i],ith_PIDscenario));
-    hNsigmaP_afterPIDcuts_TOF_trueProton[i] = (TH2F*) fIn->Get(Form("%s/hNsigmaP_%s_afterPIDcuts_TOF_trueProton_sce%i", pathRecPIDScenario.Data(),pname[i],ith_PIDscenario));
     hNsigmaP_TOF_trueElec[i]->GetYaxis()->SetTitle(Form("N#sigma_{%s}^{TOF}", plabel[i]));
     hNsigmaP_TOF_trueMuon[i]->GetYaxis()->SetTitle(Form("N#sigma_{%s}^{TOF}", plabel[i]));
     hNsigmaP_TOF_truePion[i]->GetYaxis()->SetTitle(Form("N#sigma_{%s}^{TOF}", plabel[i]));
@@ -526,14 +490,10 @@ if (bPlotPIDhistograms) {
     hNsigmaP_RICH_trueElec[i] = (TH2F*) fIn->Get(Form("hNsigmaP_%s_RICH_trueElec", pname[i]));
     hNsigmaP_RICH_trueMuon[i] = (TH2F*) fIn->Get(Form("hNsigmaP_%s_RICH_trueMuon", pname[i]));
     hNsigmaP_RICH_truePion[i] = (TH2F*) fIn->Get(Form("hNsigmaP_%s_RICH_truePion", pname[i]));
-    hNsigmaP_RICH_trueKaon[i] = (TH2F*) fIn->Get(Form("hNsigmaP_%s_RICH_trueKaon", pname[i]));
-    hNsigmaP_RICH_trueProton[i] = (TH2F*) fIn->Get(Form("hNsigmaP_%s_RICH_trueProton", pname[i]));
     hNsigmaP_afterPIDcuts_RICH[i] = (TH2F*) fIn->Get(Form("%s/hNsigmaP_%s_afterPIDcuts_RICH_sce%i",pathRecPIDScenario.Data(), pname[i], ith_PIDscenario));
     hNsigmaP_afterPIDcuts_RICH_trueElec[i] = (TH2F*) fIn->Get(Form("%s/hNsigmaP_%s_afterPIDcuts_RICH_trueElec_sce%i",pathRecPIDScenario.Data(), pname[i], ith_PIDscenario));
     hNsigmaP_afterPIDcuts_RICH_trueMuon[i] = (TH2F*) fIn->Get(Form("%s/hNsigmaP_%s_afterPIDcuts_RICH_trueMuon_sce%i",pathRecPIDScenario.Data(), pname[i], ith_PIDscenario));
     hNsigmaP_afterPIDcuts_RICH_truePion[i] = (TH2F*) fIn->Get(Form("%s/hNsigmaP_%s_afterPIDcuts_RICH_truePion_sce%i",pathRecPIDScenario.Data(), pname[i], ith_PIDscenario));
-    hNsigmaP_afterPIDcuts_RICH_trueKaon[i] = (TH2F*) fIn->Get(Form("%s/hNsigmaP_%s_afterPIDcuts_RICH_trueKaon_sce%i",pathRecPIDScenario.Data(), pname[i], ith_PIDscenario));
-    hNsigmaP_afterPIDcuts_RICH_trueProton[i] = (TH2F*) fIn->Get(Form("%s/hNsigmaP_%s_afterPIDcuts_RICH_trueProton_sce%i",pathRecPIDScenario.Data(), pname[i], ith_PIDscenario));
     hNsigmaP_RICH_trueElec[i]->GetYaxis()->SetTitle(Form("N#sigma_{%s}^{RICH}", plabel[i]));
     hNsigmaP_RICH_trueMuon[i]->GetYaxis()->SetTitle(Form("N#sigma_{%s}^{RICH}", plabel[i]));
     hNsigmaP_RICH_truePion[i]->GetYaxis()->SetTitle(Form("N#sigma_{%s}^{RICH}", plabel[i]));
@@ -573,12 +533,9 @@ if (bPlotPIDhistograms) {
   vecHistosNSigma.push_back((TH2F*)hNsigmaP_RICH_truePion[2]);
 }
 
-  //Pair histograms M,pT,DCA
+  //Pair histograms M,pT
   TH3F* hMPtDCA_ULS_rec = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_rec_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_ULS_primary_rec = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_rec_primary_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_ULS_HF_rec = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_rec_heavy_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_ULS_CC_rec = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_rec_charm_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_ULS_BB_rec = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_rec_beauty_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
+
   TH3F* hMPtDCA_ULS_rec_MCpidEle = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_rec_MCpidEle_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
   TH3F* hMPtDCA_ULS_rec_MCpidEle_charmTOe = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_rec_MCpidEle_charmTOe_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
   TH3F* hMPtDCA_ULS_rec_MCpidEle_beautyTOe = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_rec_MCpidEle_beautyTOe_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
@@ -589,10 +546,7 @@ if (bPlotPIDhistograms) {
   TH3F* hMPtDCA_ULS_rec_MCpidEle_hfTOee = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_rec_MCpidEle_hfTOee_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
 
   TH3F* hMPtDCA_ULS_gen = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_gen_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_ULS_primary_gen = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_gen_primary_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_ULS_HF_gen = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_gen_heavy_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_ULS_CC_gen = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_gen_charm_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_ULS_BB_gen = (TH3F*) fIn->Get(Form("%s/hMPtDCA_ULS_gen_beauty_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
+
 
   TH3F* hMPtDCA_LS_rec = (TH3F*) fIn->Get(Form("%s/hMPtDCA_LS_rec_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
   TH3F* hMPtDCA_LS_rec_MCpidEle = (TH3F*) fIn->Get(Form("%s/hMPtDCA_LS_rec_MCpidEle_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
@@ -605,68 +559,7 @@ if (bPlotPIDhistograms) {
   TH3F* hMPtDCA_LS_rec_bbTOee = (TH3F*) fIn->Get(Form("%s/hMPtDCA_LS_rec_bbTOee_sce%i",pathRecPIDScenario.Data(),ith_PIDscenario));
 
   TH3F* hMPtDCA_LS_gen = (TH3F*) fIn->Get(Form("%s/hMPtDCA_LS_gen_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_LS_primary_gen = (TH3F*) fIn->Get(Form("%s/hMPtDCA_LS_gen_primary_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_LS_HF_gen = (TH3F*) fIn->Get(Form("%s/hMPtDCA_LS_gen_heavy_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_LS_CC_gen = (TH3F*) fIn->Get(Form("%s/hMPtDCA_LS_gen_charm_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
-  // TH3F* hMPtDCA_LS_BB_gen = (TH3F*) fIn->Get(Form("%s/hMPtDCA_LS_gen_beauty_sce%i",pathGenPIDScenario.Data(),ith_PIDscenario));
 
-
-  // create projections and profiles
-  // TH1F* ptRecTrackPrim  = (TH1F*) hRec_TrackPtEtaPhi_primary->ProjectionX("rec ptTrackPrim");
-  // TH1F* ptRecEleTrackPrim  = (TH1F*) hRecEle_TrackPtEtaPhi_primary->ProjectionX("rec e- ptTrackPrim");
-  // TH1F* ptRecPosTrackPrim  = (TH1F*) hRecPos_TrackPtEtaPhi_primary->ProjectionX("rec e+ ptTrackPrim");
-  // TH1F* etaRecTrackPrim = (TH1F*) hRec_TrackPtEtaPhi_primary->ProjectionY("rec etaTrackPrim");
-  // TH1F* etaRecEleTrackPrim = (TH1F*) hRecEle_TrackPtEtaPhi_primary->ProjectionY("rec e- etaTrackPrim");
-  // TH1F* etaRecPosTrackPrim = (TH1F*) hRecPos_TrackPtEtaPhi_primary->ProjectionY("rec e+ etaTrackPrim");
-  // TH1F* phiRecTrackPrim = (TH1F*) hRec_TrackPtEtaPhi_primary->ProjectionZ("rec phiTrackPrim");
-  // TH1F* phiRecEleTrackPrim = (TH1F*) hRecEle_TrackPtEtaPhi_primary->ProjectionZ("rec e- phiTrackPrim");
-  // TH1F* phiRecPosTrackPrim = (TH1F*) hRecPos_TrackPtEtaPhi_primary->ProjectionZ("rec e+ phiTrackPrim");
-  // TH1F* ptRecTrackCC  = (TH1F*) hRec_TrackPtEtaPhi_cc->ProjectionX("rec ptTrackCC");
-  // TH1F* ptRecEleTrackCC  = (TH1F*) hRecEle_TrackPtEtaPhi_cc->ProjectionX("rec e- ptTrackCC");
-  // TH1F* ptRecPosTrackCC  = (TH1F*) hRecPos_TrackPtEtaPhi_cc->ProjectionX("rec e+ ptTrackCC");
-  // TH1F* etaRecTrackCC = (TH1F*) hRec_TrackPtEtaPhi_cc->ProjectionY("rec etaTrackCC");
-  // TH1F* etaRecEleTrackCC = (TH1F*) hRecEle_TrackPtEtaPhi_cc->ProjectionY("rec e- etaTrackCC");
-  // TH1F* etaRecPosTrackCC = (TH1F*) hRecPos_TrackPtEtaPhi_cc->ProjectionY("rec e+ etaTrackCC");
-  // TH1F* phiRecTrackCC = (TH1F*) hRec_TrackPtEtaPhi_cc->ProjectionZ("rec phiTrackCC");
-  // TH1F* phiRecEleTrackCC = (TH1F*) hRecEle_TrackPtEtaPhi_cc->ProjectionZ("rec e- phiTrackCC");
-  // TH1F* phiRecPosTrackCC = (TH1F*) hRecPos_TrackPtEtaPhi_cc->ProjectionZ("rec e+ phiTrackCC");
-  // TH1F* ptRecTrackBB  = (TH1F*) hRec_TrackPtEtaPhi_bb->ProjectionX("rec ptTrackBB");
-  // TH1F* ptRecEleTrackBB  = (TH1F*) hRecEle_TrackPtEtaPhi_bb->ProjectionX("rec e- ptTrackBB");
-  // TH1F* ptRecPosTrackBB  = (TH1F*) hRecPos_TrackPtEtaPhi_bb->ProjectionX("rec e+ ptTrackBB");
-  // TH1F* etaRecTrackBB = (TH1F*) hRec_TrackPtEtaPhi_bb->ProjectionY("rec etaTrackBB");
-  // TH1F* etaRecEleTrackBB = (TH1F*) hRecEle_TrackPtEtaPhi_bb->ProjectionY("rec e- etaTrackBB");
-  // TH1F* etaRecPosTrackBB = (TH1F*) hRecPos_TrackPtEtaPhi_bb->ProjectionY("rec e+ etaTrackBB");
-  // TH1F* phiRecTrackBB = (TH1F*) hRec_TrackPtEtaPhi_bb->ProjectionZ("rec phiTrackBB");
-  // TH1F* phiRecEleTrackBB = (TH1F*) hRecEle_TrackPtEtaPhi_bb->ProjectionZ("rec e- phiTrackBB");
-  // TH1F* phiRecPosTrackBB = (TH1F*) hRecPos_TrackPtEtaPhi_bb->ProjectionZ("rec e+ phiTrackBB");
-
-  // TH1F* ptGenTrackPrim  = (TH1F*) hGen_TrackPtEtaPhi_primary->ProjectionX("gen ptTrackPrim");
-  // TH1F* ptGenEleTrackPrim  = (TH1F*) hGenEle_TrackPtEtaPhi_primary->ProjectionX("gen e- ptTrackPrim");
-  // TH1F* ptGenPosTrackPrim  = (TH1F*) hGenPos_TrackPtEtaPhi_primary->ProjectionX("gen e+ ptTrackPrim");
-  // TH1F* etaGenTrackPrim = (TH1F*) hGen_TrackPtEtaPhi_primary->ProjectionY("gen etaTrackPrim");
-  // TH1F* etaGenEleTrackPrim = (TH1F*) hGenEle_TrackPtEtaPhi_primary->ProjectionY("gen e- etaTrackPrim");
-  // TH1F* etaGenPosTrackPrim = (TH1F*) hGenPos_TrackPtEtaPhi_primary->ProjectionY("gen e+ etaTrackPrim");
-  // TH1F* phiGenTrackPrim = (TH1F*) hGen_TrackPtEtaPhi_primary->ProjectionZ("gen phiTrackPrim");
-  // TH1F* phiGenEleTrackPrim = (TH1F*) hGenEle_TrackPtEtaPhi_primary->ProjectionZ("gen e- phiTrackPrim");
-  // TH1F* phiGenPosTrackPrim = (TH1F*) hGenPos_TrackPtEtaPhi_primary->ProjectionZ("gen e+ phiTrackPrim");
-  // TH1F* ptGenTrackCC  = (TH1F*) hGen_TrackPtEtaPhi_cc->ProjectionX("gen ptTrackCC");
-  // TH1F* ptGenEleTrackCC  = (TH1F*) hGenEle_TrackPtEtaPhi_cc->ProjectionX("gen e- ptTrackCC");
-  // TH1F* ptGenPosTrackCC  = (TH1F*) hGenPos_TrackPtEtaPhi_cc->ProjectionX("gen e+ ptTrackCC");
-  // TH1F* etaGenTrackCC = (TH1F*) hGen_TrackPtEtaPhi_cc->ProjectionY("gen etaTrackCC");
-  // TH1F* etaGenEleTrackCC = (TH1F*) hGenEle_TrackPtEtaPhi_cc->ProjectionY("gen e- etaTrackCC");
-  // TH1F* etaGenPosTrackCC = (TH1F*) hGenPos_TrackPtEtaPhi_cc->ProjectionY("gen e+ etaTrackCC");
-  // TH1F* phiGenTrackCC = (TH1F*) hGen_TrackPtEtaPhi_cc->ProjectionZ("gen phiTrackCC");
-  // TH1F* phiGenEleTrackCC = (TH1F*) hGenEle_TrackPtEtaPhi_cc->ProjectionZ("gen e- phiTrackCC");
-  // TH1F* phiGenPosTrackCC = (TH1F*) hGenPos_TrackPtEtaPhi_cc->ProjectionZ("gen e+ phiTrackCC");
-  // TH1F* ptGenTrackBB  = (TH1F*) hGen_TrackPtEtaPhi_bb->ProjectionX("gen ptTrackBB");
-  // TH1F* ptGenEleTrackBB  = (TH1F*) hGenEle_TrackPtEtaPhi_bb->ProjectionX("gen e- ptTrackBB");
-  // TH1F* ptGenPosTrackBB  = (TH1F*) hGenPos_TrackPtEtaPhi_bb->ProjectionX("gen e+ ptTrackBB");
-  // TH1F* etaGenTrackBB = (TH1F*) hGen_TrackPtEtaPhi_bb->ProjectionY("gen etaTrackBB");
-  // TH1F* etaGenEleTrackBB = (TH1F*) hGenEle_TrackPtEtaPhi_bb->ProjectionY("gen e- etaTrackBB");
-  // TH1F* etaGenPosTrackBB = (TH1F*) hGenPos_TrackPtEtaPhi_bb->ProjectionY("gen e+ etaTrackBB");
-  // TH1F* phiGenTrackBB = (TH1F*) hGen_TrackPtEtaPhi_bb->ProjectionZ("gen phiTrackBB");
-  // TH1F* phiGenEleTrackBB = (TH1F*) hGenEle_TrackPtEtaPhi_bb->ProjectionZ("gen e- phiTrackBB");
-  // TH1F* phiGenPosTrackBB = (TH1F*) hGenPos_TrackPtEtaPhi_bb->ProjectionZ("gen e+ phiTrackBB");
 
   TH1F* ptRecTrackBeforeSmearing  = (TH1F*) hRec_Track_Pt_Eta_Phi_BeforeSmearing->ProjectionX("Rec beforeSmearing ptTrack");
   TH1F* etaRecTrackBeforeSmearing = (TH1F*) hRec_Track_Pt_Eta_Phi_BeforeSmearing->ProjectionY("Rec beforeSmearing etaTrack");
@@ -694,14 +587,6 @@ if (bPlotPIDhistograms) {
 
   TH2F* ptEtaRecTrackElePos = (TH2F*) hRec_Track_ElePos_Pt_Eta_Phi->Project3D("yx o");
 
-  TH1F* ptRecTrackEle  = (TH1F*) hRec_Track_Ele_Pt_Eta_Phi->ProjectionX("Rec electrons ptTrack");
-  TH1F* etaRecTrackEle = (TH1F*) hRec_Track_Ele_Pt_Eta_Phi->ProjectionY("Rec electrons etaTrack");
-  TH1F* phiRecTrackEle = (TH1F*) hRec_Track_Ele_Pt_Eta_Phi->ProjectionZ("Rec electrons phiTrack");
-
-  TH1F* ptRecTrackPos  = (TH1F*) hRec_Track_Pos_Pt_Eta_Phi->ProjectionX("Rec positrons ptTrack");
-  TH1F* etaRecTrackPos = (TH1F*) hRec_Track_Pos_Pt_Eta_Phi->ProjectionY("Rec positrons etaTrack");
-  TH1F* phiRecTrackPos = (TH1F*) hRec_Track_Pos_Pt_Eta_Phi->ProjectionZ("Rec positrons phiTrack");
-
   TH1F* ptAllRecTrack  = (TH1F*) hRec_AllTrack_Pt_Eta_Phi->ProjectionX("Rec ptTrack");
   TH1F* etaAllRecTrack = (TH1F*) hRec_AllTrack_Pt_Eta_Phi->ProjectionY("Rec etaTrack");
   TH1F* phiAllRecTrack = (TH1F*) hRec_AllTrack_Pt_Eta_Phi->ProjectionZ("Rec phiTrack");
@@ -723,12 +608,8 @@ if (bPlotPIDhistograms) {
   TH1F* phiRecPionTrack = (TH1F*) hRec_Track_Pion_Pt_Eta_Phi->ProjectionZ("Rec Pion phiTrack");
 
   TH1F* ptRecKaonTrack  = (TH1F*) hRec_Track_Kaon_Pt_Eta_Phi->ProjectionX("Rec Kaon ptTrack");
-  TH1F* etaRecKaonTrack = (TH1F*) hRec_Track_Kaon_Pt_Eta_Phi->ProjectionY("Rec Kaon etaTrack");
-  TH1F* phiRecKaonTrack = (TH1F*) hRec_Track_Kaon_Pt_Eta_Phi->ProjectionZ("Rec Kaon phiTrack");
-
   TH1F* ptRecProtonTrack  = (TH1F*) hRec_Track_Proton_Pt_Eta_Phi->ProjectionX("Rec Proton ptTrack");
-  TH1F* etaRecProtonTrack = (TH1F*) hRec_Track_Proton_Pt_Eta_Phi->ProjectionY("Rec Proton etaTrack");
-  TH1F* phiRecProtonTrack = (TH1F*) hRec_Track_Proton_Pt_Eta_Phi->ProjectionZ("Rec Proton phiTrack");
+
 
   TH1F* ptGenTrackElePos_beforeKineCuts  = (TH1F*) hGen_Track_ElePos_Pt_Eta_Phi_beforeKineCuts->ProjectionX("Gen ElePos ptTrack beforeKineCuts");
   TH1F* etaGenTrackElePos_beforeKineCuts = (TH1F*) hGen_Track_ElePos_Pt_Eta_Phi_beforeKineCuts->ProjectionY("Gen ElePos etaTrack beforeKineCuts");
@@ -740,23 +621,17 @@ if (bPlotPIDhistograms) {
 
   TH2F* ptEtaGenTrackElePos = (TH2F*) hGen_Track_ElePos_Pt_Eta_Phi->Project3D("yx o");
 
+  // TH1F* ptGenTrackElePos_LF  = (TH1F*) hGen_Track_ElePos_LF_Pt_Eta_Phi->ProjectionX("Gen ElePos from LF ptTrack");
   TH1F* ptGenTrackElePos_HF  = (TH1F*) hGen_Track_ElePos_HF_Pt_Eta_Phi->ProjectionX("Gen ElePos from HF ptTrack");
 
   TH1F* ptGenTrackAll   = (TH1F*) hGen_Track_All_Pt_Eta_Phi->ProjectionX("Gen All ptTrack");
   TH1F* ptGenTrackMuon  = (TH1F*) hGen_Track_Muon_Pt_Eta_Phi->ProjectionX("Gen Muon ptTrack");
   TH1F* ptGenTrackPion  = (TH1F*) hGen_Track_Pion_Pt_Eta_Phi->ProjectionX("Gen Pion ptTrack");
-  TH1F* ptGenTrackKaon  = (TH1F*) hGen_Track_Kaon_Pt_Eta_Phi->ProjectionX("Gen Kaon ptTrack");
-  TH1F* ptGenTrackProton  = (TH1F*) hGen_Track_Proton_Pt_Eta_Phi->ProjectionX("Gen Proton ptTrack");
-  TH1F* ptGenTrackPionRapSel  = (TH1F*) hGen_Track_Pion_Pt_Rap_Phi->ProjectionX("Gen Pion ptTrack");
+  // TH1F* ptGenTrackKaon  = (TH1F*) hGen_Track_Kaon_Pt_Eta_Phi->ProjectionX("Gen Kaon ptTrack");
+  // TH1F* ptGenTrackProton  = (TH1F*) hGen_Track_Proton_Pt_Eta_Phi->ProjectionX("Gen Proton ptTrack");
+  TH1F* ptGenTrackPionRapSel  = (TH1F*) hGen_Track_Pion_Pt_Rap_Phi->ProjectionX("Gen Pion ptTrack RapSel");
 
 
-  TH1F* ptGenTrackEle  = (TH1F*) hGen_Track_Ele_Pt_Eta_Phi->ProjectionX("Gen electrons ptTrack");
-  TH1F* etaGenTrackEle = (TH1F*) hGen_Track_Ele_Pt_Eta_Phi->ProjectionY("Gen electrons etaTrack");
-  TH1F* phiGenTrackEle = (TH1F*) hGen_Track_Ele_Pt_Eta_Phi->ProjectionZ("Gen electrons phiTrack");
-
-  TH1F* ptGenTrackPos  = (TH1F*) hGen_Track_Pos_Pt_Eta_Phi->ProjectionX("Gen positrons ptTrack");
-  TH1F* etaGenTrackPos = (TH1F*) hGen_Track_Pos_Pt_Eta_Phi->ProjectionY("Gen positrons etaTrack");
-  TH1F* phiGenTrackPos = (TH1F*) hGen_Track_Pos_Pt_Eta_Phi->ProjectionZ("Gen positrons phiTrack");
 
   // TH1F* ptGenSmearedTrackElePos_beforeKineCuts  = (TH1F*) hGenSmeared_Track_ElePos_Pt_Eta_Phi_beforeKineCuts->ProjectionX("GenSmeared ElePos ptTrack beforeKineCuts");
   // TH1F* etaGenSmearedTrackElePos_beforeKineCuts = (TH1F*) hGenSmeared_Track_ElePos_Pt_Eta_Phi_beforeKineCuts->ProjectionY("GenSmeared ElePos etaTrack beforeKineCuts");
@@ -766,61 +641,30 @@ if (bPlotPIDhistograms) {
   TH1F* etaGenSmearedTrackElePos = (TH1F*) hGenSmeared_Track_ElePos_Pt_Eta_Phi->ProjectionY("GenSmeared ElePos etaTrack");
   TH1F* phiGenSmearedTrackElePos = (TH1F*) hGenSmeared_Track_ElePos_Pt_Eta_Phi->ProjectionZ("GenSmeared ElePos phiTrack");
 
-  TH1F* ptGenSmearedTrackEle  = (TH1F*) hGenSmeared_Track_Ele_Pt_Eta_Phi->ProjectionX("GenSmeared electrons ptTrack");
-  TH1F* etaGenSmearedTrackEle = (TH1F*) hGenSmeared_Track_Ele_Pt_Eta_Phi->ProjectionY("GenSmeared electrons etaTrack");
-  TH1F* phiGenSmearedTrackEle = (TH1F*) hGenSmeared_Track_Ele_Pt_Eta_Phi->ProjectionZ("GenSmeared electrons phiTrack");
-
-  TH1F* ptGenSmearedTrackPos  = (TH1F*) hGenSmeared_Track_Pos_Pt_Eta_Phi->ProjectionX("GenSmeared positrons ptTrack");
-  TH1F* etaGenSmearedTrackPos = (TH1F*) hGenSmeared_Track_Pos_Pt_Eta_Phi->ProjectionY("GenSmeared positrons etaTrack");
-  TH1F* phiGenSmearedTrackPos = (TH1F*) hGenSmeared_Track_Pos_Pt_Eta_Phi->ProjectionZ("GenSmeared positrons phiTrack");
-
-  etaGenSmearedTrackPos->GetXaxis()->SetRangeUser(-5.0,5.0);
-
-
-
-  // TH1F* ptRecTrackEtaCut_1 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut1->ProjectionX("Rec eta1cut pt Track");
-  // TH1F* ptRecTrackEtaCut_2 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut2->ProjectionX("Rec eta2cut pt Track");
-  // TH1F* ptRecTrackEtaCut_3 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut3->ProjectionX("Rec eta3cut pt Track");
-  // TH1F* ptRecTrackEtaCut_4 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut4->ProjectionX("Rec eta4cut pt Track");
-  // TH1F* ptRecTrackEtaCut_5 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut5->ProjectionX("Rec eta5cut pt Track");
-  // TH1F* ptRecTrackEtaCut_6 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut6->ProjectionX("Rec eta6cut pt Track");
-  // TH1F* ptRecTrackEtaCut_7 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut7->ProjectionX("Rec eta7cut pt Track");
-  // TH1F* ptRecTrackEtaCut_8 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut8->ProjectionX("Rec eta8cut pt Track");
-  // TH1F* ptRecTrackEtaCut_9 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut9->ProjectionX("Rec eta9cut pt Track");
-  // TH1F* ptRecTrackEtaCut_10 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut10->ProjectionX("Rec eta10cut pt Track");
-  //
-  // TH1F* etaRecTrackEtaCut_1 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut1->ProjectionY("Rec eta1cut eta Track");
-  // TH1F* etaRecTrackEtaCut_2 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut2->ProjectionY("Rec eta2cut eta Track");
-  // TH1F* etaRecTrackEtaCut_3 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut3->ProjectionY("Rec eta3cut eta Track");
-  // TH1F* etaRecTrackEtaCut_4 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut4->ProjectionY("Rec eta4cut eta Track");
-  // TH1F* etaRecTrackEtaCut_5 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut5->ProjectionY("Rec eta5cut eta Track");
-  // TH1F* etaRecTrackEtaCut_6 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut6->ProjectionY("Rec eta6cut eta Track");
-  // TH1F* etaRecTrackEtaCut_7 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut7->ProjectionY("Rec eta7cut eta Track");
-  // TH1F* etaRecTrackEtaCut_8 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut8->ProjectionY("Rec eta8cut eta Track");
-  // TH1F* etaRecTrackEtaCut_9 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut9->ProjectionY("Rec eta9cut eta Track");
-  // TH1F* etaRecTrackEtaCut_10 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut10->ProjectionY("Rec eta10cut eta Track");
-  //
-  // TH1F* phiRecTrackEtaCut_1 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut1->ProjectionZ("Rec eta1cut phi Track");
-  // TH1F* phiRecTrackEtaCut_2 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut2->ProjectionZ("Rec eta2cut phi Track");
-  // TH1F* phiRecTrackEtaCut_3 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut3->ProjectionZ("Rec eta3cut phi Track");
-  // TH1F* phiRecTrackEtaCut_4 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut4->ProjectionZ("Rec eta4cut phi Track");
-  // TH1F* phiRecTrackEtaCut_5 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut5->ProjectionZ("Rec eta5cut phi Track");
-  // TH1F* phiRecTrackEtaCut_6 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut6->ProjectionZ("Rec eta6cut phi Track");
-  // TH1F* phiRecTrackEtaCut_7 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut7->ProjectionZ("Rec eta7cut phi Track");
-  // TH1F* phiRecTrackEtaCut_8 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut8->ProjectionZ("Rec eta8cut phi Track");
-  // TH1F* phiRecTrackEtaCut_9 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut9->ProjectionZ("Rec eta9cut phi Track");
-  // TH1F* phiRecTrackEtaCut_10 = (TH1F*) hRec_Track_Pt_Eta_Phi_EtaCut10->ProjectionZ("Rec eta10cut phi Track");
-
 
     TH1F* hParticlesFIT = (TH1F*) fIn->Get("nParticlesFIT");
     Int_t nentries=0;
     Int_t nbins = hParticlesFIT->GetXaxis()->GetNbins();
     Int_t centralNinetyPercent = hParticlesFIT->GetEntries() * 0.9;
+    Int_t centralsixtyPercent = hParticlesFIT->GetEntries() * 0.6;
+    Int_t centralfortyPercent = hParticlesFIT->GetEntries() * 0.4;
     cout  << nbins << endl;
     for (size_t ibin = 1; ibin < nbins ; ibin++) {
       if(nentries >= centralNinetyPercent) continue; // look for the lowest 90% to find the lower egde of the 10% cental events
       nentries = nentries + hParticlesFIT->GetBinContent(ibin);
       if(nentries >= centralNinetyPercent) cout << "nentries has reached 10% at " << hParticlesFIT->GetXaxis()->GetBinCenter(ibin) << endl;
+    }
+    nentries=0;
+    for (size_t ibin = 1; ibin < nbins ; ibin++) {
+      if(nentries >= centralsixtyPercent) continue; // look for the lowest 60% to find the lower egde of the 40% cental events
+      nentries = nentries + hParticlesFIT->GetBinContent(ibin);
+      if(nentries >= centralsixtyPercent) cout << "nentries has reached 40% at " << hParticlesFIT->GetXaxis()->GetBinCenter(ibin) << endl;
+    }
+    nentries=0;
+    for (size_t ibin = 1; ibin < nbins ; ibin++) {
+      if(nentries >= centralfortyPercent) continue; // look for the lowest 40% to find the lower egde of the 60% cental events
+      nentries = nentries + hParticlesFIT->GetBinContent(ibin);
+      if(nentries >= centralfortyPercent) cout << "nentries has reached 60% at " << hParticlesFIT->GetXaxis()->GetBinCenter(ibin) << endl;
     }
 
     TH1F* hdNdeta_midrap = (TH1F*) fIn->Get("hdNdeta_midrap_gen");
@@ -894,17 +738,10 @@ if (bPlotPIDhistograms) {
   // Profiles to see M_ee and pT_ee spectras
     TH1F* proj_recULS_Mee = (TH1F*) hMPtDCA_ULS_rec->ProjectionX("proj_recULS_Mee");
     TH1F* proj_recULS_Ptee = (TH1F*) hMPtDCA_ULS_rec->ProjectionY("proj_recULS_Ptee");
-    TH1F* proj_recULS_DCA = (TH1F*) hMPtDCA_ULS_rec->ProjectionZ("proj_recULS_DCA");
-    // TH1F* proj_recULS_MeePrim = (TH1F*) hMPtDCA_ULS_primary_rec->ProjectionX("proj_recULS_MeePrim");
-    // TH1F* proj_recULS_PteePrim = (TH1F*) hMPtDCA_ULS_primary_rec->ProjectionY("proj_recULS_PteePrim");
-    // TH1F* proj_recULS_MeeCC = (TH1F*) hMPtDCA_ULS_CC_rec->ProjectionX("proj_recULS_MeeCC");
-    // TH1F* proj_recULS_PteeCC = (TH1F*) hMPtDCA_ULS_CC_rec->ProjectionY("proj_recULS_PteeCC");
-    // TH1F* proj_recULS_MeeBB = (TH1F*) hMPtDCA_ULS_BB_rec->ProjectionX("proj_recULS_MeeBB");
-    // TH1F* proj_recULS_PteeBB = (TH1F*) hMPtDCA_ULS_BB_rec->ProjectionY("proj_recULS_PteeBB");
+
 
     // TH1F* proj_recULS_MCpidEle_Mee = (TH1F*) hMPtDCA_ULS_rec_MCpidEle->ProjectionX("proj_recULS_MCpidEle_Mee");
     // TH1F* proj_recULS_MCpidEle_Ptee = (TH1F*) hMPtDCA_ULS_rec_MCpidEle->ProjectionY("proj_recULS_MCpidEle_Ptee");
-    TH2F* mptRecTrackElePos = (TH2F*) hMPtDCA_ULS_rec_MCpidEle->Project3D("yx o");
 
     TH1F* proj_recULS_MCpidEle_charmTOe_Mee = (TH1F*) hMPtDCA_ULS_rec_MCpidEle_charmTOe->ProjectionX("proj_recULS_Mee_charmTOe");
     TH1F* proj_recULS_MCpidEle_beautyTOe_Mee = (TH1F*) hMPtDCA_ULS_rec_MCpidEle_beautyTOe->ProjectionX("proj_recULS_Mee_beautyTOe");
@@ -917,32 +754,41 @@ if (bPlotPIDhistograms) {
 
     TH1F* proj_recLS_Mee = (TH1F*) hMPtDCA_LS_rec->ProjectionX("proj_recLS_Mee");
     TH1F* proj_recLS_Ptee = (TH1F*) hMPtDCA_LS_rec->ProjectionY("proj_recLS_Ptee");
-    TH1F* proj_recLS_DCA = (TH1F*) hMPtDCA_LS_rec->ProjectionZ("proj_recLS_DCA");
+
+    printf(" dcacut %i\n", DCAcut);
 
 
-    TH1F* proj_recLS_MCpidEle_Mee = (TH1F*) hMPtDCA_LS_rec_MCpidEle->ProjectionX("proj_recLS_MCpidEle_Mee");
-    TH1F* proj_recLS_MCpidEle_Ptee = (TH1F*) hMPtDCA_LS_rec_MCpidEle->ProjectionY("proj_recLS_MCpidEle_Ptee");
-    TH1F* proj_recLS_MCpidEle_DCA = (TH1F*) hMPtDCA_LS_rec_MCpidEle->ProjectionZ("proj_recLS_MCpidEle_DCA");
+    // DCA cut on pairs
+    if(DCAcut) hMPtDCA_LS_rec_MCpidEle->GetZaxis()->SetRangeUser(0.,1.2);
+    if(DCAcut) hMPtDCA_LS_rec_lfTOee_selectPDG->GetZaxis()->SetRangeUser(0.,1.2);
+    if(DCAcut) hMPtDCA_LS_rec_hfTOe->GetZaxis()->SetRangeUser(0.,1.2);
+    if(DCAcut) hMPtDCA_LS_rec_hfTOee->GetZaxis()->SetRangeUser(0.,1.2);
+
+    TH1F* proj_recLS_MCpidEle_Mee = (TH1F*) hMPtDCA_LS_rec_MCpidEle->Project3D("x");
+    TH1F* proj_recLS_MCpidEle_Ptee = (TH1F*) hMPtDCA_LS_rec_MCpidEle->Project3D("y");
+    proj_recLS_MCpidEle_Mee->SetTitle("proj_recLS_MCpidEle_Mee");
+    proj_recLS_MCpidEle_Ptee->SetTitle("proj_recLS_MCpidEle_Ptee");
 
     TH1F* proj_recLS_Ctoe_Mee  = (TH1F*) hMPtDCA_LS_rec_charmTOe->ProjectionX("proj_recLS_Ctoe_Mee");
     TH1F* proj_recLS_Ctoe_Ptee = (TH1F*) hMPtDCA_LS_rec_charmTOe->ProjectionY("proj_recLS_Ctoe_Ptee");
-    TH1F* proj_recLS_Ctoe_DCA  = (TH1F*) hMPtDCA_LS_rec_charmTOe->ProjectionZ("proj_recLS_Ctoe_DCA");
 
     TH1F* proj_recLS_Btoe_Mee  = (TH1F*) hMPtDCA_LS_rec_beautyTOe->ProjectionX("proj_recLS_Btoe_Mee");
     TH1F* proj_recLS_Btoe_Ptee = (TH1F*) hMPtDCA_LS_rec_beautyTOe->ProjectionY("proj_recLS_Btoe_Ptee");
-    TH1F* proj_recLS_Btoe_DCA  = (TH1F*) hMPtDCA_LS_rec_beautyTOe->ProjectionZ("proj_recLS_Btoe_DCA");
 
-    TH1F* proj_recLS_HFtoe_Mee  = (TH1F*) hMPtDCA_LS_rec_hfTOe->ProjectionX("proj_recLS_HFtoe_Mee");
-    TH1F* proj_recLS_HFtoe_Ptee = (TH1F*) hMPtDCA_LS_rec_hfTOe->ProjectionY("proj_recLS_HFtoe_Ptee");
-    TH1F* proj_recLS_HFtoe_DCA  = (TH1F*) hMPtDCA_LS_rec_hfTOe->ProjectionZ("proj_recLS_HFtoe_DCA");
+    TH1F* proj_recLS_HFtoe_Mee  = (TH1F*) hMPtDCA_LS_rec_hfTOe->Project3D("x");
+    TH1F* proj_recLS_HFtoe_Ptee = (TH1F*) hMPtDCA_LS_rec_hfTOe->Project3D("y");
+    proj_recLS_HFtoe_Mee->SetTitle("proj_recLS_HFtoe_Mee");
+    proj_recLS_HFtoe_Ptee->SetTitle("proj_recLS_HFtoe_Ptee");
 
-    TH1F* proj_recLS_LFtoee_Mee  = (TH1F*) hMPtDCA_LS_rec_lfTOee_selectPDG->ProjectionX("proj_recLS_LFtoee_Mee");
-    TH1F* proj_recLS_LFtoee_Ptee = (TH1F*) hMPtDCA_LS_rec_lfTOee_selectPDG->ProjectionY("proj_recLS_LFtoee_Ptee");
-    TH1F* proj_recLS_LFtoee_DCA  = (TH1F*) hMPtDCA_LS_rec_lfTOee_selectPDG->ProjectionZ("proj_recLS_LFtoee_DCA");
+    TH1F* proj_recLS_LFtoee_Mee  = (TH1F*) hMPtDCA_LS_rec_lfTOee_selectPDG->Project3D("x"); //Project3D("x")
+    TH1F* proj_recLS_LFtoee_Ptee = (TH1F*) hMPtDCA_LS_rec_lfTOee_selectPDG->Project3D("y");
+    proj_recLS_LFtoee_Mee->SetTitle("proj_recLS_LFtoee_Mee");
+    proj_recLS_LFtoee_Ptee->SetTitle("proj_recLS_LFtoee_Ptee");
 
-    TH1F* proj_recLS_HFtoee_Mee  = (TH1F*) hMPtDCA_LS_rec_hfTOee->ProjectionX("proj_recLS_HFtoee_Mee");
-    TH1F* proj_recLS_HFtoee_Ptee = (TH1F*) hMPtDCA_LS_rec_hfTOee->ProjectionY("proj_recLS_HFtoee_Ptee");
-    TH1F* proj_recLS_HFtoee_DCA  = (TH1F*) hMPtDCA_LS_rec_hfTOee->ProjectionZ("proj_recLS_HFtoee_DCA");
+    TH1F* proj_recLS_HFtoee_Mee  = (TH1F*) hMPtDCA_LS_rec_hfTOee->Project3D("x");
+    TH1F* proj_recLS_HFtoee_Ptee = (TH1F*) hMPtDCA_LS_rec_hfTOee->Project3D("y");
+    proj_recLS_HFtoee_Mee->SetTitle("proj_recLS_HFtoee_Mee");
+    proj_recLS_HFtoee_Ptee->SetTitle("proj_recLS_HFtoee_Ptee");
 
     TH1F* proj_recLS_ccTOee_Mee  = (TH1F*) hMPtDCA_LS_rec_ccTOee->ProjectionX("proj_recLS_cctoee_Mee");
     TH1F* proj_recLS_bbTOee_Mee  = (TH1F*) hMPtDCA_LS_rec_bbTOee->ProjectionX("proj_recLS_bbtoee_Mee");
@@ -950,104 +796,78 @@ if (bPlotPIDhistograms) {
 
     TH1F* proj_genULS_Mee = (TH1F*) hMPtDCA_ULS_gen->ProjectionX("proj_genULS_Mee");
     TH1F* proj_genULS_Ptee = (TH1F*) hMPtDCA_ULS_gen->ProjectionY("proj_genULS_Ptee");
-    TH1F* proj_genULS_DCA = (TH1F*) hMPtDCA_ULS_gen->ProjectionZ("proj_genULS_DCA");
 
-    TH2F* mptGenTrackElePos = (TH2F*) hMPtDCA_ULS_gen->Project3D("yx o");
 
     TH1F* proj_genLS_Mee = (TH1F*) hMPtDCA_LS_gen->ProjectionX("proj_genLS_Mee");
     TH1F* proj_genLS_Ptee = (TH1F*) hMPtDCA_LS_gen->ProjectionY("proj_genLS_Ptee");
-    TH1F* proj_genLS_DCA = (TH1F*) hMPtDCA_LS_gen->ProjectionZ("proj_genLS_DCA");
 
 
     proj_recULS_Mee->Scale(1./nEventsCent);
     proj_recULS_Ptee->Scale(1./nEventsCent);
-    proj_recULS_DCA->Scale(1./nEventsCent);
 
     proj_recLS_Mee->Scale(1./nEventsCent);
     proj_recLS_Ptee->Scale(1./nEventsCent);
-    proj_recLS_DCA->Scale(1./nEventsCent);
 
     proj_genULS_Mee->Scale(1./nEventsCent);
     proj_genULS_Ptee->Scale(1./nEventsCent);
-    proj_genULS_DCA->Scale(1./nEventsCent);
     proj_genLS_Mee->Scale(1./nEventsCent);
     proj_genLS_Ptee->Scale(1./nEventsCent);
-    proj_genLS_DCA->Scale(1./nEventsCent);
 
-
+    double etacoverage = 2*etaCutsVec[ith_PIDscenario];
     // normlise by Nevents, dy = 1.6 (for |eta|<0.8)
-    proj_recULS_MCpidEle_charmTOe_Mee->Scale(1/(1.6*nEventsCent));
-    proj_recULS_MCpidEle_beautyTOe_Mee->Scale(1/(1.6*nEventsCent));
-    proj_recULS_MCpidEle_hfTOe_Mee->Scale(1/(1.6*nEventsCent));
-    proj_recULS_MCpidEle_lfTOee_Mee->Scale(1/(1.6*nEventsCent));
-    proj_recULS_MCpidEle_ccTOee_Mee->Scale(1/(1.6*nEventsCent));
-    proj_recULS_MCpidEle_bbTOee_Mee->Scale(1/(1.6*nEventsCent));
-    proj_recULS_MCpidEle_hfTOee_Mee->Scale(1/(1.6*nEventsCent));
+    proj_recULS_MCpidEle_charmTOe_Mee->Scale(1/(etacoverage*nEventsCent));
+    proj_recULS_MCpidEle_beautyTOe_Mee->Scale(1/(etacoverage*nEventsCent));
+    proj_recULS_MCpidEle_hfTOe_Mee->Scale(1/(etacoverage*nEventsCent));
+    proj_recULS_MCpidEle_lfTOee_Mee->Scale(1/(etacoverage*nEventsCent));
+    proj_recULS_MCpidEle_ccTOee_Mee->Scale(1/(etacoverage*nEventsCent));
+    proj_recULS_MCpidEle_bbTOee_Mee->Scale(1/(etacoverage*nEventsCent));
+    proj_recULS_MCpidEle_hfTOee_Mee->Scale(1/(etacoverage*nEventsCent));
 
-    proj_recLS_Ctoe_Mee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_Ctoe_Ptee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_Ctoe_DCA->Scale(1./(1.6*nEventsCent));
-    proj_recLS_Btoe_Mee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_Btoe_Ptee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_Btoe_DCA->Scale(1./(1.6*nEventsCent));
-    proj_recLS_HFtoe_Mee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_HFtoe_Ptee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_HFtoe_DCA->Scale(1./(1.6*nEventsCent));
-    proj_recLS_MCpidEle_Mee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_MCpidEle_Ptee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_MCpidEle_DCA->Scale(1./(1.6*nEventsCent));
+    proj_recLS_Ctoe_Mee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_Ctoe_Ptee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_Btoe_Mee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_Btoe_Ptee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_HFtoe_Mee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_HFtoe_Ptee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_MCpidEle_Mee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_MCpidEle_Ptee->Scale(1./(etacoverage*nEventsCent));
 
-    proj_recLS_LFtoee_Mee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_LFtoee_Ptee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_LFtoee_DCA->Scale(1./(1.6*nEventsCent));
-    proj_recLS_HFtoee_Mee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_HFtoee_Ptee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_HFtoee_DCA->Scale(1./(1.6*nEventsCent));
-    proj_recLS_ccTOee_Mee->Scale(1./(1.6*nEventsCent));
-    proj_recLS_bbTOee_Mee->Scale(1./(1.6*nEventsCent));
+    proj_recLS_LFtoee_Mee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_LFtoee_Ptee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_HFtoee_Mee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_HFtoee_Ptee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_ccTOee_Mee->Scale(1./(etacoverage*nEventsCent));
+    proj_recLS_bbTOee_Mee->Scale(1./(etacoverage*nEventsCent));
 
 
     normalizeToBinWidth(proj_recULS_Mee);
     normalizeToBinWidth(proj_recULS_Ptee);
-    normalizeToBinWidth(proj_recULS_DCA);
 
     normalizeToBinWidth(proj_recLS_Mee);
     normalizeToBinWidth(proj_recLS_Ptee);
-    normalizeToBinWidth(proj_recLS_DCA);
 
     normalizeToBinWidth(proj_genULS_Mee);
     normalizeToBinWidth(proj_genULS_Ptee);
-    normalizeToBinWidth(proj_genULS_DCA);
     normalizeToBinWidth(proj_genLS_Mee);
     normalizeToBinWidth(proj_genLS_Ptee);
-    normalizeToBinWidth(proj_genLS_DCA);
 
-    normalizeToBinWidth(proj_recLS_MCpidEle_Ptee);
-    normalizeToBinWidth(proj_recLS_LFtoee_Ptee);
-    normalizeToBinWidth(proj_recLS_HFtoe_Ptee);
-    normalizeToBinWidth(proj_recLS_MCpidEle_DCA);
-    normalizeToBinWidth(proj_recLS_LFtoee_DCA);
-    normalizeToBinWidth(proj_recLS_HFtoe_DCA);
+    // normalizeToBinWidth(proj_recLS_MCpidEle_Ptee);
+    // normalizeToBinWidth(proj_recLS_LFtoee_Ptee);
+    // normalizeToBinWidth(proj_recLS_HFtoe_Ptee);
 
 
     make3HistNice(proj_recLS_MCpidEle_Mee,kBlack);
     make3HistNice(proj_recLS_MCpidEle_Ptee,kBlack);
-    make3HistNice(proj_recLS_MCpidEle_DCA,kBlack);
     make3HistNice(proj_recLS_Ctoe_Mee,kOrange+2);
     make3HistNice(proj_recLS_Ctoe_Ptee,kOrange+2);
-    make3HistNice(proj_recLS_Ctoe_DCA,kOrange+2);
     make3HistNice(proj_recLS_Btoe_Mee,kMagenta+1);
     make3HistNice(proj_recLS_Btoe_Ptee,kMagenta+1);
-    make3HistNice(proj_recLS_Btoe_DCA,kMagenta+1);
     make3HistNice(proj_recLS_HFtoe_Mee,kRed+2);
     make3HistNice(proj_recLS_HFtoe_Ptee,kRed+2);
-    make3HistNice(proj_recLS_HFtoe_DCA,kRed+2);
     make3HistNice(proj_recLS_LFtoee_Mee,kCyan+1);
     make3HistNice(proj_recLS_LFtoee_Ptee,kCyan+1);
-    make3HistNice(proj_recLS_LFtoee_DCA,kCyan+1);
     make3HistNice(proj_recLS_HFtoee_Mee,kRed+2);
     make3HistNice(proj_recLS_HFtoee_Ptee,kRed+2);
-    make3HistNice(proj_recLS_HFtoee_DCA,kRed+2);
     makeHistNice(proj_recLS_ccTOee_Mee,kOrange+2);
     makeHistNice(proj_recLS_bbTOee_Mee,kMagenta+1);
 
@@ -1062,51 +882,41 @@ if (bPlotPIDhistograms) {
 
 
 
- TH1F* ptRecTrackBeforeSmearing_rebin = (TH1F*) ptRecTrackBeforeSmearing->Rebin(nbinspt_proj,"ptRecTrackBeforeSmearing_rebin",&pt_bin_proj[0]);
- TH1F* ptRecTrackAfterSmearing_rebin = (TH1F*) ptRecTrackAfterSmearing->Rebin(nbinspt_proj,"ptRecTrackAfterSmearing_rebin",&pt_bin_proj[0]);
- TH1F* ptRecTrackAfterKineCuts_rebin = (TH1F*) ptRecTrackAfterKineCuts->Rebin(nbinspt_proj,"ptRecTrackAfterKineCuts_rebin",&pt_bin_proj[0]);
+ TH1F* ptRecTrackBeforeSmearing_rebin = (TH1F*) ptRecTrackBeforeSmearing->Rebin(nbinspt_proj_2D,"ptRecTrackBeforeSmearing_rebin",&pte_bin_2D[0]);
+ TH1F* ptRecTrackAfterSmearing_rebin = (TH1F*) ptRecTrackAfterSmearing->Rebin(nbinspt_proj_2D,"ptRecTrackAfterSmearing_rebin",&pte_bin_2D[0]);
+ TH1F* ptRecTrackAfterKineCuts_rebin = (TH1F*) ptRecTrackAfterKineCuts->Rebin(nbinspt_proj_2D,"ptRecTrackAfterKineCuts_rebin",&pte_bin_2D[0]);
 
- TH1F* ptRecTrackElePos_rebin = (TH1F*) ptRecTrackElePos->Rebin(nbinspt_proj,"ptRecTrackElePos_rebin",&pt_bin_proj[0]);
- TH1F* ptGenTrackElePos_rebin = (TH1F*) ptGenTrackElePos->Rebin(nbinspt_proj,"ptGenTrackElePos_rebin",&pt_bin_proj[0]);
- TH1F* ptGenTrackAll_rebin = (TH1F*) ptGenTrackAll->Rebin(nbinspt_proj,"ptGenTrackAll_rebin",&pt_bin_proj[0]);
- TH1F* ptGenTrackMuon_rebin = (TH1F*) ptGenTrackMuon->Rebin(nbinspt_proj,"ptGenTrackMuon_rebin",&pt_bin_proj[0]);
- TH1F* ptGenTrackPion_rebin = (TH1F*) ptGenTrackPion->Rebin(nbinspt_proj,"ptGenTrackPion_rebin",&pt_bin_proj[0]);
- TH1F* ptGenTrackKaon_rebin = (TH1F*) ptGenTrackKaon->Rebin(nbinspt_proj,"ptGenTrackKaon_rebin",&pt_bin_proj[0]);
- TH1F* ptGenTrackProton_rebin = (TH1F*) ptGenTrackProton->Rebin(nbinspt_proj,"ptGenTrackProton_rebin",&pt_bin_proj[0]);
- TH1F* ptGenSmearedTrackElePos_rebin = (TH1F*) ptGenSmearedTrackElePos->Rebin(nbinspt_proj,"ptGenSmearedTrackElePos_rebin",&pt_bin_proj[0]);
- TH1F* ptGenTrackElePos_beforeKineCuts_rebin = (TH1F*) ptGenTrackElePos_beforeKineCuts->Rebin(nbinspt_proj,"ptGenTrackElePos_beforeKineCuts_rebin",&pt_bin_proj[0]);
- // TH1F* ptGenSmearedTrackElePos_beforeKineCuts_rebin = (TH1F*) ptGenSmearedTrackElePos_beforeKineCuts->Rebin(nbinspt_proj,"ptGenSmearedTrackElePos_beforeKineCuts_rebin",&pt_bin_proj[0]);
- TH1F* ptGenTrackElePos_HF_rebin = (TH1F*) ptGenTrackElePos_HF->Rebin(nbinspt_proj_10,"ptGenTrackElePos_HF_rebin",&pt_bin_proj_10[0]);
- // cout << __LINE__ <<  " COUT "  << endl;
- TH1F* hRec_Track_Pt_hasPS_rebin = (TH1F*) hRec_Track_Pt_hasPS->Rebin(nbinspt_proj,"hRec_Track_Pt_hasPS_rebin",&pt_bin_proj[0]);
-
+ TH1F* ptRecTrackElePos_rebin = (TH1F*) ptRecTrackElePos->Rebin(nbinspt_proj_2D,"ptRecTrackElePos_rebin",&pte_bin_2D[0]);
+ TH1F* ptGenTrackElePos_rebin = (TH1F*) ptGenTrackElePos->Rebin(nbinspt_proj_2D,"ptGenTrackElePos_rebin",&pte_bin_2D[0]);
+ TH1F* ptGenTrackAll_rebin = (TH1F*) ptGenTrackAll->Rebin(nbinspt_proj_2D,"ptGenTrackAll_rebin",&pte_bin_2D[0]);
+ TH1F* ptGenTrackMuon_rebin = (TH1F*) ptGenTrackMuon->Rebin(nbinspt_proj_2D,"ptGenTrackMuon_rebin",&pte_bin_2D[0]);
+ TH1F* ptGenTrackPion_rebin = (TH1F*) ptGenTrackPion->Rebin(nbinspt_proj_2D,"ptGenTrackPion_rebin",&pte_bin_2D[0]);
+ // TH1F* ptGenTrackKaon_rebin = (TH1F*) ptGenTrackKaon->Rebin(nbinspt_proj_2D,"ptGenTrackKaon_rebin",&pte_bin_2D[0]);
+ // TH1F* ptGenTrackProton_rebin = (TH1F*) ptGenTrackProton->Rebin(nbinspt_proj_2D,"ptGenTrackProton_rebin",&pte_bin_2D[0]);
+ TH1F* ptGenSmearedTrackElePos_rebin = (TH1F*) ptGenSmearedTrackElePos->Rebin(nbinspt_proj_2D,"ptGenSmearedTrackElePos_rebin",&pte_bin_2D[0]);
+ TH1F* ptGenTrackElePos_beforeKineCuts_rebin = (TH1F*) ptGenTrackElePos_beforeKineCuts->Rebin(nbinspt_proj_2D,"ptGenTrackElePos_beforeKineCuts_rebin",&pte_bin_2D[0]);
+ // TH1F* ptGenSmearedTrackElePos_beforeKineCuts_rebin = (TH1F*) ptGenSmearedTrackElePos_beforeKineCuts->Rebin(nbinspt_proj_2D,"ptGenSmearedTrackElePos_beforeKineCuts_rebin",&pte_bin_2D[0]);
+ // TH1F* ptGenTrackElePos_LF_rebin = (TH1F*) ptGenTrackElePos_LF->Rebin(nbinspt_proj_2D,"ptGenTrackElePos_LF_rebin",&pte_bin_2D[0]);
+ TH1F* ptGenTrackElePos_HF_rebin = (TH1F*) ptGenTrackElePos_HF->Rebin(nbinspt_proj_2D,"ptGenTrackElePos_HF_rebin",&pte_bin_2D[0]);
 
 
- TH1F* ptRecTrackElePos_Pi0_beforePID_rebin = (TH1F*) ptRecTrackElePos_Pi0_beforePID->Rebin(nbinspt_proj,"ptRecTrackElePos_Pi0_beforePID_rebin",&pt_bin_proj[0]);
- TH1F* ptRecTrackElePos_LF_beforePID_rebin = (TH1F*) ptRecTrackElePos_LF_beforePID->Rebin(nbinspt_proj,"ptRecTrackElePos_LF_beforePID_rebin",&pt_bin_proj[0]);
- TH1F* ptRecTrackElePos_HF_beforePID_rebin = (TH1F*) ptRecTrackElePos_HF_beforePID->Rebin(nbinspt_proj,"ptRecTrackElePos_HF_beforePID_rebin",&pt_bin_proj[0]);
 
- TH1F* ptRecTrackElePos_Pi0_afterPID_rebin = (TH1F*) ptRecTrackElePos_Pi0_afterPID->Rebin(nbinspt_proj,"ptRecTrackElePos_Pi0_afterPID_rebin",&pt_bin_proj[0]);
- TH1F* ptRecTrackElePos_LF_afterPID_rebin = (TH1F*) ptRecTrackElePos_LF_afterPID->Rebin(nbinspt_proj,"ptRecTrackElePos_LF_afterPID_rebin",&pt_bin_proj[0]);
- TH1F* ptRecTrackElePos_HF_afterPID_rebin = (TH1F*) ptRecTrackElePos_HF_afterPID->Rebin(nbinspt_proj,"ptRecTrackElePos_HF_afterPID_rebin",&pt_bin_proj[0]);
+ TH1F* ptRecTrackElePos_Pi0_beforePID_rebin = (TH1F*) ptRecTrackElePos_Pi0_beforePID->Rebin(nbinspt_proj_2D,"ptRecTrackElePos_Pi0_beforePID_rebin",&pte_bin_2D[0]);
+ TH1F* ptRecTrackElePos_LF_beforePID_rebin = (TH1F*) ptRecTrackElePos_LF_beforePID->Rebin(nbinspt_proj_2D,"ptRecTrackElePos_LF_beforePID_rebin",&pte_bin_2D[0]);
+ TH1F* ptRecTrackElePos_HF_beforePID_rebin = (TH1F*) ptRecTrackElePos_HF_beforePID->Rebin(nbinspt_proj_2D,"ptRecTrackElePos_HF_beforePID_rebin",&pte_bin_2D[0]);
 
- TH1F* ptAllRecTrack_rebin = (TH1F*) ptAllRecTrack->Rebin(nbinspt_proj,"ptAllRecTrack_rebin",&pt_bin_proj[0]);
- TH1F* ptRecMuonTrack_rebin = (TH1F*) ptRecMuonTrack->Rebin(nbinspt_proj,"ptRecMuonTrack_rebin",&pt_bin_proj[0]);
- TH1F* ptRecPionTrack_rebin = (TH1F*) ptRecPionTrack->Rebin(nbinspt_proj,"ptRecPionTrack_rebin",&pt_bin_proj[0]);
- TH1F* ptRecKaonTrack_rebin = (TH1F*) ptRecKaonTrack->Rebin(nbinspt_proj,"ptRecKaonTrack_rebin",&pt_bin_proj[0]);
- TH1F* ptRecProtonTrack_rebin = (TH1F*) ptRecProtonTrack->Rebin(nbinspt_proj,"ptRecProtonTrack_rebin",&pt_bin_proj[0]);
+ TH1F* ptRecTrackElePos_Pi0_afterPID_rebin = (TH1F*) ptRecTrackElePos_Pi0_afterPID->Rebin(nbinspt_proj_2D,"ptRecTrackElePos_Pi0_afterPID_rebin",&pte_bin_2D[0]);
+ TH1F* ptRecTrackElePos_LF_afterPID_rebin = (TH1F*) ptRecTrackElePos_LF_afterPID->Rebin(nbinspt_proj_2D,"ptRecTrackElePos_LF_afterPID_rebin",&pte_bin_2D[0]);
+ TH1F* ptRecTrackElePos_HF_afterPID_rebin = (TH1F*) ptRecTrackElePos_HF_afterPID->Rebin(nbinspt_proj_2D,"ptRecTrackElePos_HF_afterPID_rebin",&pte_bin_2D[0]);
 
- TH1F* ptRecNegTrack_rebin = (TH1F*) ptRecNegTrack->Rebin(nbinspt_proj,"ptRecNegTrack_rebin",&pt_bin_proj[0]);
- TH1F* ptRecPosTrack_rebin = (TH1F*) ptRecPosTrack->Rebin(nbinspt_proj,"ptRecPosTrack_rebin",&pt_bin_proj[0]);
+ TH1F* ptAllRecTrack_rebin = (TH1F*) ptAllRecTrack->Rebin(nbinspt_proj_2D,"ptAllRecTrack_rebin",&pte_bin_2D[0]);
+ TH1F* ptRecMuonTrack_rebin = (TH1F*) ptRecMuonTrack->Rebin(nbinspt_proj_2D,"ptRecMuonTrack_rebin",&pte_bin_2D[0]);
+ TH1F* ptRecPionTrack_rebin = (TH1F*) ptRecPionTrack->Rebin(nbinspt_proj_2D,"ptRecPionTrack_rebin",&pte_bin_2D[0]);
+ TH1F* ptRecKaonTrack_rebin = (TH1F*) ptRecKaonTrack->Rebin(nbinspt_proj_2D,"ptRecKaonTrack_rebin",&pte_bin_2D[0]);
+ TH1F* ptRecProtonTrack_rebin = (TH1F*) ptRecProtonTrack->Rebin(nbinspt_proj_2D,"ptRecProtonTrack_rebin",&pte_bin_2D[0]);
 
-
- TH1F* ptRecTrackEle_rebin = (TH1F*) ptRecTrackEle->Rebin(nbinspt_proj,"ptRecTrackEle_rebin",&pt_bin_proj[0]);
- TH1F* ptRecTrackPos_rebin = (TH1F*) ptRecTrackPos->Rebin(nbinspt_proj,"ptRecTrackPos_rebin",&pt_bin_proj[0]);
- TH1F* ptGenSmearedTrackEle_rebin = (TH1F*) ptGenSmearedTrackEle->Rebin(nbinspt_proj,"ptGenSmearedTrackEle_rebin",&pt_bin_proj[0]);
- TH1F* ptGenSmearedTrackPos_rebin = (TH1F*) ptGenSmearedTrackPos->Rebin(nbinspt_proj,"ptGenSmearedTrackPos_rebin",&pt_bin_proj[0]);
- TH1F* ptGenTrackEle_rebin = (TH1F*) ptGenTrackEle->Rebin(nbinspt_proj,"ptGenTrackEle_rebin",&pt_bin_proj[0]);
- TH1F* ptGenTrackPos_rebin = (TH1F*) ptGenTrackPos->Rebin(nbinspt_proj,"ptGenTrackPos_rebin",&pt_bin_proj[0]);
-
+ TH1F* ptRecNegTrack_rebin = (TH1F*) ptRecNegTrack->Rebin(nbinspt_proj_2D,"ptRecNegTrack_rebin",&pte_bin_2D[0]);
+ TH1F* ptRecPosTrack_rebin = (TH1F*) ptRecPosTrack->Rebin(nbinspt_proj_2D,"ptRecPosTrack_rebin",&pte_bin_2D[0]);
 
 
   TH1F* projNSigmas_afterCuts_trueElec;
@@ -1124,31 +934,9 @@ if (bPlotPIDhistograms) {
   TH1F* ptEffElePosGen;
   TH1F* ptEffElePosGenSmeared;
   TH1F* ptEffElePosGen_woPID;
-  TH1F* ptEffEle;
-  TH1F* ptEffElePOS_PreShower;
-  // TH1F* ptEffElePrim;
-  // TH1F* ptEffEleCC;
-  // TH1F* ptEffEleBB;
-  TH1F* etaEffEle;
-  // TH1F* etaEffElePrim;
-  // TH1F* etaEffEleCC;
-  // TH1F* etaEffEleBB;
-  TH1F* phiEffEle;
-  // TH1F* phiEffElePrim;
-  // TH1F* phiEffEleCC;
-  // TH1F* phiEffEleBB;
-  TH1F* ptEffPos;
-  // TH1F* ptEffPosPrim;
-  // TH1F* ptEffPosCC;
-  // TH1F* ptEffPosBB;
-  TH1F* etaEffPos;
-  // TH1F* etaEffPosPrim;
-  // TH1F* etaEffPosCC;
-  // TH1F* etaEffPosBB;
-  TH1F* phiEffPos;
-  // TH1F* phiEffPosPrim;
-  // TH1F* phiEffPosCC;
-  // TH1F* phiEffPosBB;
+  TH1F* ptEffElePos_PreShower;
+  // TH1F* ptEffElePos_LF_afterPF;
+  TH1F* ptEffElePos_HF_afterPF;
 
   TH2F* ptEtaEffElePos;
   TH2F* mPtPairEffElePos;
@@ -1225,48 +1013,23 @@ if (bPlotPIDhistograms) {
 
 
     ptEffElePosGen = (TH1F*) ptRecTrackElePos_rebin->Clone("eff_pT_singleElePos_Gen");
-    // ptEffElePosGen->Sumw2();
     ptEffElePosGen->Divide(ptEffElePosGen,ptGenTrackElePos_rebin,1,1,"B");
     ptEffElePosGenSmeared = (TH1F*) ptRecTrackElePos_rebin->Clone("eff_pT_singleElePos_GenSmeared");
-    // ptEffElePosGenSmeared->Sumw2();
     ptEffElePosGenSmeared->Divide(ptEffElePosGenSmeared,ptGenSmearedTrackElePos_rebin,1,1,"B");
 
     ptEffElePosGen_woPID = (TH1F*) ptRecTrackAfterKineCuts_rebin->Clone("eff_pT_singleElePos_Gen_woPID");
-    // ptEffElePosGen_woPID->Sumw2();
     ptEffElePosGen_woPID->Divide(ptEffElePosGen_woPID,ptGenTrackElePos_rebin,1,1,"B");
-
-    ptEffEle = (TH1F*) ptRecTrackEle_rebin->Clone("eff_pT_singleElectrons");
-    // ptEffEle->Sumw2();
-    // ptEffEle->Divide(ptEffEle,ptGenSmearedTrackEle_rebin,1,1,"B");
-    ptEffEle->Divide(ptEffEle,ptGenTrackEle_rebin,1,1,"B");
-    etaEffEle = (TH1F*) etaRecTrackEle->Clone("eff_eta_singleElectrons");
-    // etaEffEle->Sumw2();
-    // etaEffEle->Divide(etaEffEle,etaGenSmearedTrackEle,1,1,"B");
-    etaEffEle->Divide(etaEffEle,etaGenTrackEle,1,1,"B");
-    phiEffEle = (TH1F*) phiRecTrackEle->Clone("eff_phi_singleElectrons");
-    // phiEffEle->Sumw2();
-    // phiEffEle->Divide(phiEffEle,phiGenSmearedTrackEle,1,1,"B");
-    phiEffEle->Divide(phiEffEle,phiGenTrackEle,1,1,"B");
-    // ptEffPos = (TH1F*) ptRecPosTrackPrim->Clone("eff_pT_singlePositrons");
-    // ptEffPos->Add(ptRecPosTrackCC, 1);
-    // ptEffPos->Add(ptRecPosTrackBB, 1);
-    ptEffPos = (TH1F*) ptRecTrackPos_rebin->Clone("eff_pT_singlePositrons");
-    // ptEffPos->Sumw2();
-    // ptEffPos->Divide(ptEffPos,ptGenSmearedTrackPos_rebin,1,1,"B");
-    ptEffPos->Divide(ptEffPos,ptGenTrackPos_rebin,1,1,"B");
-    etaEffPos = (TH1F*) etaRecTrackPos->Clone("eff_eta_singlePositrons");
-    // etaEffPos->Sumw2();
-    // etaEffPos->Divide(etaEffPos,etaGenSmearedTrackPos,1,1,"B");
-    etaEffPos->Divide(etaEffPos,etaGenTrackPos,1,1,"B");
-    phiEffPos = (TH1F*) phiRecTrackPos->Clone("eff_phi_singlePositrons");
-    // phiEffPos->Sumw2();
-    // phiEffPos->Divide(phiEffPos,phiGenSmearedTrackPos,1,1,"B");
-    phiEffPos->Divide(phiEffPos,phiGenTrackPos,1,1,"B");
 
     // single track efficiency TH2 as function of pt and eta
     ptEtaEffElePos = (TH2F*) ptEtaRecTrackElePos->Clone("eff_ptEta_singleElePos");
-    // ptEtaEffElePos->Sumw2();
     ptEtaEffElePos->Divide(ptEtaEffElePos,ptEtaGenTrackElePos,1,1,"B");
+
+    // ptEffElePos_LF_afterPF = (TH1F*) ptRecTrackElePos_LF_afterPID_rebin->Clone("eff_pT_singleElePos_LF_afterPF");
+    // ptEffElePos_LF_afterPF->Divide(ptEffElePos_LF_afterPF,ptGenTrackElePos_LF_rebin,1,1,"B");
+
+    ptEffElePos_HF_afterPF = (TH1F*) ptRecTrackElePos_HF_afterPID_rebin->Clone("eff_pT_singleElePos_HF_afterPF");
+    ptEffElePos_HF_afterPF->Divide(ptEffElePos_HF_afterPF,ptGenTrackElePos_HF_rebin,1,1,"B");
+
 
    // pair efficiencies
    // // ptPairEffULS = (TH1F*) proj_recULS_Ptee->Clone();
@@ -1278,72 +1041,53 @@ if (bPlotPIDhistograms) {
    // ptPairEffULS->Divide(ptPairEffULS,proj_genULS_Ptee,1,1,"B");
    // massPairEffULS->Divide(massPairEffULS,proj_genULS_Mee,1,1,"B");
 
-   mPtPairEffElePos = (TH2F*) mptRecTrackElePos->Clone("pairEff_mPt_ElePos");
+   mPtPairEffElePos = (TH2F*) hMPtDCA_ULS_rec_MCpidEle->Clone("pairEff_mPt_ElePos");
    // mPtPairEffElePos->Sumw2();
-   mPtPairEffElePos->Divide(mPtPairEffElePos,mptGenTrackElePos,1,1,"B");
+   mPtPairEffElePos->Divide(mPtPairEffElePos,hMPtDCA_ULS_gen,1,1,"B");
 
-   ptEffElePOS_PreShower = (TH1F*) hRec_Track_Pt_hasPS_rebin->Clone("eff_pT_ElePos_PreShower");
-   ptEffElePOS_PreShower->Divide(ptEffElePOS_PreShower,ptGenTrackElePos_rebin,1,1,"B");
+   ptEffElePos_PreShower = (TH1F*) ptRecTrackElePos_rebin->Clone("eff_pT_ElePos_PreShower");
+   ptEffElePos_PreShower->Divide(ptEffElePos_PreShower,ptGenTrackElePos_rebin,1,1,"B");
 
   }
 
 
   TH1F* hMuonRejectionFactorPt;
   TH1F* hPionRejectionFactorPt;
-  TH1F* hKaonRejectionFactorPt;
-  TH1F* hProtonRejectionFactorPt;
+  // TH1F* hKaonRejectionFactorPt;
+  // TH1F* hProtonRejectionFactorPt;
   TH1F* hTotalRejectionFactorPt;
   TH1F* ptRecContamination;
   ptRecContamination = (TH1F*)  ptAllRecTrack_rebin->Clone("pt_Total_contamination");
   ptRecContamination->Add(ptRecTrackElePos_rebin,-1);
 
-
   hMuonRejectionFactorPt = (TH1F*) ptGenTrackMuon_rebin->Clone("pT_Muon_Rejectionfactor");
   hPionRejectionFactorPt = (TH1F*) ptGenTrackPion_rebin->Clone("pT_Pion_Rejectionfactor");
-  hKaonRejectionFactorPt = (TH1F*) ptGenTrackKaon_rebin->Clone("pT_Kaon_Rejectionfactor");
-  hProtonRejectionFactorPt = (TH1F*) ptGenTrackProton_rebin->Clone("pT_Proton_Rejectionfactor");
+  // hKaonRejectionFactorPt = (TH1F*) ptGenTrackKaon_rebin->Clone("pT_Kaon_Rejectionfactor");
+  // hProtonRejectionFactorPt = (TH1F*) ptGenTrackProton_rebin->Clone("pT_Proton_Rejectionfactor");
   hTotalRejectionFactorPt = (TH1F*) ptGenTrackAll_rebin->Clone("pT_Total_Rejectionfactor");
   hTotalRejectionFactorPt->Add(ptGenTrackElePos_rebin,-1);
 
-  // hMuonRejectionFactorPt->Sumw2();
-  // hPionRejectionFactorPt->Sumw2();
-  // hKaonRejectionFactorPt->Sumw2();
-  // hProtonRejectionFactorPt->Sumw2();
-  // hTotalRejectionFactorPt->Sumw2();
 
   hMuonRejectionFactorPt->Divide(hMuonRejectionFactorPt, ptRecMuonTrack_rebin,1,1,"B");
   hPionRejectionFactorPt->Divide(hPionRejectionFactorPt, ptRecPionTrack_rebin,1,1,"B");
-  hKaonRejectionFactorPt->Divide(hKaonRejectionFactorPt, ptRecKaonTrack_rebin,1,1,"B");
-  hProtonRejectionFactorPt->Divide(hProtonRejectionFactorPt, ptRecProtonTrack_rebin,1,1,"B");
+  // hKaonRejectionFactorPt->Divide(hKaonRejectionFactorPt, ptRecKaonTrack_rebin,1,1,"B");
+  // hProtonRejectionFactorPt->Divide(hProtonRejectionFactorPt, ptRecProtonTrack_rebin,1,1,"B");
   hTotalRejectionFactorPt->Divide(hTotalRejectionFactorPt, ptRecContamination,1,1,"B");
 
 
   make3HistNice(hMuonRejectionFactorPt, kBlue+1);
   make3HistNice(hPionRejectionFactorPt, kRed+2);
-  make3HistNice(hKaonRejectionFactorPt, kGreen+2);
-  make3HistNice(hProtonRejectionFactorPt, kOrange+2);
+  // make3HistNice(hKaonRejectionFactorPt, kGreen+2);
+  // make3HistNice(hProtonRejectionFactorPt, kOrange+2);
   make3HistNice(hTotalRejectionFactorPt, kBlack);
   hTotalRejectionFactorPt->SetMarkerStyle(24);
   hTotalRejectionFactorPt->SetMarkerSize(0.9);
 
 
 
-
-  TH1F* hPurityRecPtNeg;
-  TH1F* hPurityRecEtaNeg;
-  TH1F* hPurityRecPhiNeg;
-  TH1F* hPurityRecPtPos;
-  TH1F* hPurityRecEtaPos;
-  TH1F* hPurityRecPhiPos;
   TH1F* hTotalPureContaminationRecPt;
   TH1F* hTotalPureContaminationRecEta;
   TH1F* hTotalPureContaminationRecPhi;
-  TH1F* hPureContaminationRecPtNeg;
-  TH1F* hPureContaminationRecEtaNeg;
-  TH1F* hPureContaminationRecPhiNeg;
-  TH1F* hPureContaminationRecPtPos;
-  TH1F* hPureContaminationRecEtaPos;
-  TH1F* hPureContaminationRecPhiPos;
   TH1F* hTotalRecTrackPt;
   TH1F* hTotalRecTrackEta;
   TH1F* hTotalRecTrackPhi;
@@ -1354,41 +1098,18 @@ if (bPlotPIDhistograms) {
   TH1F* hPionContaminationRecEta;
   TH1F* hPionContaminationRecPhi;
   TH1F* hKaonContaminationRecPt;
-  TH1F* hKaonContaminationRecEta;
-  TH1F* hKaonContaminationRecPhi;
   TH1F* hProtonContaminationRecPt;
-  TH1F* hProtonContaminationRecEta;
-  TH1F* hProtonContaminationRecPhi;
+
 
 
 if (bPlotTrackContamination) {
   hTotalRecTrackPt = (TH1F*)  ptAllRecTrack_rebin->Clone();
   hTotalRecTrackEta = (TH1F*) etaAllRecTrack->Clone();
   hTotalRecTrackPhi = (TH1F*) phiAllRecTrack->Clone();
-  hPurityRecPtNeg = (TH1F*)  ptRecNegTrack->Clone();
-  hPurityRecEtaNeg = (TH1F*) etaRecNegTrack->Clone();
-  hPurityRecPhiNeg = (TH1F*) phiRecNegTrack->Clone();
-  hPurityRecPtPos = (TH1F*)  ptRecPosTrack->Clone();
-  hPurityRecEtaPos = (TH1F*) etaRecPosTrack->Clone();
-  hPurityRecPhiPos = (TH1F*) phiRecPosTrack->Clone();
-
-  hPurityRecPtNeg->Divide(ptRecTrackEle,ptRecNegTrack,1,1,"B");
-  hPurityRecEtaNeg->Divide(etaRecTrackEle,etaRecNegTrack,1,1,"B");
-  hPurityRecPhiNeg->Divide(phiRecTrackEle,phiRecNegTrack,1,1,"B");
-  hPurityRecPtPos->Divide(ptRecTrackPos,ptRecPosTrack,1,1,"B");
-  hPurityRecEtaPos->Divide(etaRecTrackPos,etaRecPosTrack,1,1,"B");
-  hPurityRecPhiPos->Divide(phiRecTrackPos,phiRecPosTrack,1,1,"B");
-
 
   hTotalPureContaminationRecPt = (TH1F*)  ptAllRecTrack_rebin->Clone("TotalContaminationPt");
   hTotalPureContaminationRecEta = (TH1F*) etaAllRecTrack->Clone("TotalContaminationEta");
   hTotalPureContaminationRecPhi = (TH1F*) phiAllRecTrack->Clone("TotalContaminationPhi");
-  hPureContaminationRecPtNeg = (TH1F*)  ptRecNegTrack_rebin->Clone();
-  hPureContaminationRecEtaNeg = (TH1F*) etaRecNegTrack->Clone();
-  hPureContaminationRecPhiNeg = (TH1F*) phiRecNegTrack->Clone();
-  hPureContaminationRecPtPos = (TH1F*)  ptRecPosTrack_rebin->Clone();
-  hPureContaminationRecEtaPos = (TH1F*) etaRecPosTrack->Clone();
-  hPureContaminationRecPhiPos = (TH1F*) phiRecPosTrack->Clone();
   hMuonContaminationRecPt = (TH1F*)    ptRecMuonTrack_rebin->Clone();
   hMuonContaminationRecEta = (TH1F*)   etaRecMuonTrack->Clone();
   hMuonContaminationRecPhi = (TH1F*)   phiRecMuonTrack->Clone();
@@ -1396,11 +1117,9 @@ if (bPlotTrackContamination) {
   hPionContaminationRecEta = (TH1F*)   etaRecPionTrack->Clone();
   hPionContaminationRecPhi = (TH1F*)   phiRecPionTrack->Clone();
   hKaonContaminationRecPt = (TH1F*)    ptRecKaonTrack_rebin->Clone();
-  hKaonContaminationRecEta = (TH1F*)   etaRecKaonTrack->Clone();
-  hKaonContaminationRecPhi = (TH1F*)   phiRecKaonTrack->Clone();
   hProtonContaminationRecPt = (TH1F*)  ptRecProtonTrack_rebin->Clone();
-  hProtonContaminationRecEta = (TH1F*) etaRecProtonTrack->Clone();
-  hProtonContaminationRecPhi = (TH1F*) phiRecProtonTrack->Clone();
+
+
 
   // hTotalPureContaminationRecPt->Add(ptRecTrackElePos_rebin,-1);
   // hTotalPureContaminationRecEta->Add(etaRecTrackElePos,-1);
@@ -1438,18 +1157,7 @@ if (bPlotTrackContamination) {
    hTotalPureContaminationRecPhi->SetBinError(iBin,binError);
   }
 
-  hPureContaminationRecPtNeg->Add(ptRecTrackEle_rebin,-1);
-  hPureContaminationRecEtaNeg->Add(etaRecTrackEle,-1);
-  hPureContaminationRecPhiNeg->Add(phiRecTrackEle,-1);
-  hPureContaminationRecPtPos->Add(ptRecTrackPos_rebin,-1);
-  hPureContaminationRecEtaPos->Add(etaRecTrackPos,-1);
-  hPureContaminationRecPhiPos->Add(phiRecTrackPos,-1);
-  hPureContaminationRecPtNeg->Divide(hPureContaminationRecPtNeg,hTotalRecTrackPt,1,1,"B");
-  hPureContaminationRecEtaNeg->Divide(hPureContaminationRecEtaNeg,hTotalRecTrackEta,1,1,"B");
-  hPureContaminationRecPhiNeg->Divide(hPureContaminationRecPhiNeg,hTotalRecTrackPhi,1,1,"B");
-  hPureContaminationRecEtaPos->Divide(hPureContaminationRecEtaPos,hTotalRecTrackEta,1,1,"B");
-  hPureContaminationRecPhiPos->Divide(hPureContaminationRecPhiPos,hTotalRecTrackPhi,1,1,"B");
-  hPureContaminationRecPtPos->Divide(hPureContaminationRecPtPos,hTotalRecTrackPt,1,1,"B");
+
   hMuonContaminationRecPt->Divide(hMuonContaminationRecPt, hTotalRecTrackPt,1,1,"B");
   hMuonContaminationRecEta->Divide(hMuonContaminationRecEta, hTotalRecTrackEta,1,1,"B");
   hMuonContaminationRecPhi->Divide(hMuonContaminationRecPhi, hTotalRecTrackPhi,1,1,"B");
@@ -1457,11 +1165,8 @@ if (bPlotTrackContamination) {
   hPionContaminationRecEta->Divide(hPionContaminationRecEta, hTotalRecTrackEta,1,1,"B");
   hPionContaminationRecPhi->Divide(hPionContaminationRecPhi, hTotalRecTrackPhi,1,1,"B");
   hKaonContaminationRecPt->Divide(hKaonContaminationRecPt, hTotalRecTrackPt,1,1,"B");
-  hKaonContaminationRecPhi->Divide(hKaonContaminationRecPhi, hTotalRecTrackPhi,1,1,"B");
-  hKaonContaminationRecEta->Divide(hKaonContaminationRecEta, hTotalRecTrackEta,1,1,"B");
   hProtonContaminationRecPt->Divide(hProtonContaminationRecPt, hTotalRecTrackPt,1,1,"B");
-  hProtonContaminationRecEta->Divide(hProtonContaminationRecEta, hTotalRecTrackEta,1,1,"B");
-  hProtonContaminationRecPhi->Divide(hProtonContaminationRecPhi, hTotalRecTrackPhi,1,1,"B");
+
 
   // hTotalPureContaminationRecPt->Divide(hTotalPureContaminationRecPt,hTotalRecTrackPt,1,1,"B");
   // hTotalPureContaminationRecEta->Divide(hTotalPureContaminationRecEta,hTotalRecTrackEta,1,1,"B");
@@ -1484,19 +1189,7 @@ if (bPlotTrackContamination) {
 
 
 if (bPlotTrackContamination) {
-  make3HistNice(hPurityRecPtNeg,kBlue+1);
-  make3HistNice(hPurityRecEtaNeg,kBlue+1);
-  make3HistNice(hPurityRecPhiNeg,kBlue+1);
-  make3HistNice(hPurityRecPtPos,kRed+2);
-  make3HistNice(hPurityRecEtaPos,kRed+2);
-  make3HistNice(hPurityRecPhiPos,kRed+2);
 
-  make3HistNice(hPureContaminationRecPtNeg,kBlue+1);
-  make3HistNice(hPureContaminationRecEtaNeg,kBlue+1);
-  make3HistNice(hPureContaminationRecPhiNeg,kBlue+1);
-  make3HistNice(hPureContaminationRecPtPos,kRed+2);
-  make3HistNice(hPureContaminationRecEtaPos,kRed+2);
-  make3HistNice(hPureContaminationRecPhiPos,kRed+2);
 
   make3HistNice(hMuonContaminationRecPt, kBlue+1);
   make3HistNice(hMuonContaminationRecEta, kBlue+1);
@@ -1505,11 +1198,7 @@ if (bPlotTrackContamination) {
   make3HistNice(hPionContaminationRecEta, kRed+2);
   make3HistNice(hPionContaminationRecPhi, kRed+2);
   make3HistNice(hKaonContaminationRecPt, kGreen+2);
-  make3HistNice(hKaonContaminationRecEta, kGreen+2);
-  make3HistNice(hKaonContaminationRecPhi, kGreen+2);
   make3HistNice(hProtonContaminationRecPt, kOrange+2);
-  make3HistNice(hProtonContaminationRecEta, kOrange+2);
-  make3HistNice(hProtonContaminationRecPhi, kOrange+2);
   make3HistNice(hTotalPureContaminationRecPt, kBlack);
   make3HistNice(hTotalPureContaminationRecEta, kBlack);
   make3HistNice(hTotalPureContaminationRecPhi, kBlack);
@@ -1521,21 +1210,6 @@ if (bPlotTrackContamination) {
   hTotalPureContaminationRecPhi->SetMarkerStyle(24);
   hTotalPureContaminationRecPhi->SetMarkerSize(0.9);
 
-
-
-
-  // hPureContaminationRecPtNeg->SetMarkerStyle(24);
-  // hPureContaminationRecEtaNeg->SetMarkerStyle(24);
-  // hPureContaminationRecPhiNeg->SetMarkerStyle(24);
-  // hPureContaminationRecPtPos->SetMarkerStyle(24);
-  // hPureContaminationRecEtaPos->SetMarkerStyle(24);
-  // hPureContaminationRecPhiPos->SetMarkerStyle(24);
-  // hPureContaminationRecPtNeg->SetMarkerSize(0.9);
-  // hPureContaminationRecEtaNeg->SetMarkerSize(0.9);
-  // hPureContaminationRecPhiNeg->SetMarkerSize(0.9);
-  // hPureContaminationRecPtPos->SetMarkerSize(0.9);
-  // hPureContaminationRecEtaPos->SetMarkerSize(0.9);
-  // hPureContaminationRecPhiPos->SetMarkerSize(0.9);
 }
 
   makeHistNice(ptGenTrackElePos,kGreen+3);
@@ -1586,72 +1260,6 @@ if (bPlotTrackContamination) {
   normalizeToBinWidth(ptRecTrackElePos_HF_afterPID_rebin);
 
 
-  makeHistNice(ptRecTrackEle_rebin,kGreen+3);
-  makeHistNice(etaRecTrackEle,kGreen+3);
-  makeHistNice(phiRecTrackEle,kGreen+3);
-  makeHistNice(ptRecTrackPos_rebin,kOrange+1);
-  makeHistNice(etaRecTrackPos,kOrange+1);
-  makeHistNice(phiRecTrackPos,kOrange+1);
-  makeHistNice(ptGenTrackEle_rebin,kBlue+1);
-  makeHistNice(etaGenTrackEle,kBlue+1);
-  makeHistNice(phiGenTrackEle,kBlue+1);
-  makeHistNice(ptGenTrackPos_rebin,kRed+1);
-  makeHistNice(etaGenTrackPos,kRed+1);
-  makeHistNice(phiGenTrackPos,kRed+1);
-  ptGenTrackEle_rebin->SetMarkerStyle(24);
-  etaGenTrackEle->SetMarkerStyle(24);
-  phiGenTrackEle->SetMarkerStyle(24);
-  ptGenTrackPos_rebin->SetMarkerStyle(24);
-  etaGenTrackPos->SetMarkerStyle(24);
-  phiGenTrackPos->SetMarkerStyle(24);
-
-  // make3HistNice(ptRecTrackPrim,kBlue+1);
-  // make3HistNice(etaRecTrackPrim,kBlue+1);
-  // make3HistNice(phiRecTrackPrim,kBlue+1);
-  // make3HistNice(ptRecTrackCC,kRed+2);
-  // make3HistNice(etaRecTrackCC,kRed+2);
-  // make3HistNice(phiRecTrackCC,kRed+2);
-  // make3HistNice(ptRecTrackBB,kMagenta+1);
-  // make3HistNice(etaRecTrackBB,kMagenta+1);
-  // make3HistNice(phiRecTrackBB,kMagenta+1);
-  //
-  // make3HistNice(ptGenTrackPrim,kBlue+1);
-  // make3HistNice(etaGenTrackPrim,kBlue+1);
-  // make3HistNice(phiGenTrackPrim,kBlue+1);
-  // make3HistNice(ptGenTrackCC,kRed+2);
-  // make3HistNice(etaGenTrackCC,kRed+2);
-  // make3HistNice(phiGenTrackCC,kRed+2);
-  // make3HistNice(ptGenTrackBB,kMagenta+1);
-  // make3HistNice(etaGenTrackBB,kMagenta+1);
-  // make3HistNice(phiGenTrackBB,kMagenta+1);
-  //
-  // make3HistNice(etaGenEleTrackPrim,kBlue+1);
-  // make3HistNice(etaGenEleTrackCC,kRed+2);
-  // make3HistNice(etaGenEleTrackBB,kMagenta+1);
-  // make3HistNice(etaGenPosTrackPrim,kBlue+1);
-  // make3HistNice(etaGenPosTrackCC,kRed+2);
-  // make3HistNice(etaGenPosTrackBB,kMagenta+1);
-  // make3HistNice(etaRecEleTrackPrim,kBlue+1);
-  // make3HistNice(etaRecEleTrackCC,kRed+2);
-  // make3HistNice(etaRecEleTrackBB,kMagenta+1);
-  // make3HistNice(etaRecPosTrackPrim,kBlue+1);
-  // make3HistNice(etaRecPosTrackCC,kRed+2);
-  // make3HistNice(etaRecPosTrackBB,kMagenta+1);
-  // etaGenEleTrackPrim->SetMarkerStyle(22);
-  // etaGenEleTrackCC->SetMarkerStyle(22);
-  // etaGenEleTrackBB->SetMarkerStyle(22);
-  // etaRecEleTrackPrim->SetMarkerStyle(22);
-  // etaRecEleTrackCC->SetMarkerStyle(22);
-  // etaRecEleTrackBB->SetMarkerStyle(22);
-  // etaGenPosTrackPrim->SetMarkerStyle(24);
-  // etaGenPosTrackCC->SetMarkerStyle(24);
-  // etaGenPosTrackBB->SetMarkerStyle(24);
-  // etaRecPosTrackPrim->SetMarkerStyle(24);
-  // etaRecPosTrackCC->SetMarkerStyle(24);
-  // etaRecPosTrackBB->SetMarkerStyle(24);
-  // etaGenEleTrackPrim->SetMarkerSize(0.4);
-
-
   make3HistNice(ptRecTrackBeforeSmearing_rebin,kGreen+1);
   make3HistNice(etaRecTrackBeforeSmearing,kGreen+1);
   make3HistNice(phiRecTrackBeforeSmearing,kGreen+1);
@@ -1669,97 +1277,26 @@ if (bPlotTrackContamination) {
   normalizeToBinWidth(ptRecTrackAfterSmearing_rebin);
   normalizeToBinWidth(ptRecTrackAfterKineCuts_rebin);
 
-  // make3HistNice(ptRecTrackEtaCut_1,kOrange-5);
-  // make3HistNice(ptRecTrackEtaCut_2,kOrange-4);
-  // make3HistNice(ptRecTrackEtaCut_3,kOrange-3);
-  // make3HistNice(ptRecTrackEtaCut_4,kOrange-2);
-  // make3HistNice(ptRecTrackEtaCut_5,kOrange-1);
-  // make3HistNice(ptRecTrackEtaCut_6,kOrange);
-  // make3HistNice(ptRecTrackEtaCut_7,kOrange+1);
-  // make3HistNice(ptRecTrackEtaCut_8,kOrange+2);
-  // make3HistNice(ptRecTrackEtaCut_9,kOrange+3);
-  // make3HistNice(ptRecTrackEtaCut_10,kOrange+4);
-  //
-  // make3HistNice(etaRecTrackEtaCut_1,kOrange-5);
-  // make3HistNice(etaRecTrackEtaCut_2,kOrange-4);
-  // make3HistNice(etaRecTrackEtaCut_3,kOrange-3);
-  // make3HistNice(etaRecTrackEtaCut_4,kOrange-2);
-  // make3HistNice(etaRecTrackEtaCut_5,kOrange-1);
-  // make3HistNice(etaRecTrackEtaCut_6,kOrange);
-  // make3HistNice(etaRecTrackEtaCut_7,kOrange+1);
-  // make3HistNice(etaRecTrackEtaCut_8,kOrange+2);
-  // make3HistNice(etaRecTrackEtaCut_9,kOrange+3);
-  // make3HistNice(etaRecTrackEtaCut_10,kOrange+4);
-  //
-  // make3HistNice(phiRecTrackEtaCut_1,kOrange-5);
-  // make3HistNice(phiRecTrackEtaCut_2,kOrange-4);
-  // make3HistNice(phiRecTrackEtaCut_3,kOrange-3);
-  // make3HistNice(phiRecTrackEtaCut_4,kOrange-2);
-  // make3HistNice(phiRecTrackEtaCut_5,kOrange-1);
-  // make3HistNice(phiRecTrackEtaCut_6,kOrange);
-  // make3HistNice(phiRecTrackEtaCut_7,kOrange+1);
-  // make3HistNice(phiRecTrackEtaCut_8,kOrange+2);
-  // make3HistNice(phiRecTrackEtaCut_9,kOrange+3);
-  // make3HistNice(phiRecTrackEtaCut_10,kOrange+4);
 
 
-  // makeHistNiceTH2(hMPtDCA_ULS_primary_rec,kBlue+1);
 
   if (bPlotEfficiency) {
-    makeHistNice(ptEffEle, kBlue+1);
-    makeHistNice(etaEffEle, kBlue+1);
-    makeHistNice(phiEffEle, kBlue+1);
-    makeHistNice(ptEffPos, kRed+2);
-    makeHistNice(etaEffPos, kRed+2);
-    makeHistNice(phiEffPos, kRed+2);
-    // makeHistNice(ptEffElePrim,kBlue+1);
-    // makeHistNice(ptEffEleCC,kRed+2);
-    // makeHistNice(ptEffEleBB,kMagenta+1);
-    // makeHistNice(etaEffElePrim,kBlue+1);
-    // makeHistNice(etaEffEleCC,kRed+2);
-    // makeHistNice(etaEffEleBB,kMagenta+1);
-    // makeHistNice(phiEffElePrim,kBlue+1);
-    // makeHistNice(phiEffEleCC,kRed+2);
-    // makeHistNice(phiEffEleBB,kMagenta+1);
-    // makeHistNice(ptEffPosPrim,kBlue+1);
-    // makeHistNice(ptEffPosCC,kRed+2);
-    // makeHistNice(ptEffPosBB,kMagenta+1);
-    // makeHistNice(etaEffPosPrim,kBlue+1);
-    // makeHistNice(etaEffPosCC,kRed+2);
-    // makeHistNice(etaEffPosBB,kMagenta+1);
-    // makeHistNice(phiEffPosPrim,kBlue+1);
-    // makeHistNice(phiEffPosCC,kRed+2);
-    // makeHistNice(phiEffPosBB,kMagenta+1);
-
     makeHistNice(ptEffElePosGen,kBlue+1);
     makeHistNice(ptEffElePosGenSmeared,kRed+2);
     makeHistNice(ptEffElePosGen_woPID,kViolet+2);
 
-    makeHistNice(ptEffElePOS_PreShower,kBlue+1);
+    makeHistNice(ptEffElePos_PreShower,kBlue+1);
+    makeHistNice(ptEffElePos_HF_afterPF,kBlue+1);
+    // makeHistNice(ptEffElePos_LF_afterPF,kBlue+1);
 
   }
 
   makeHistNice(proj_recULS_Mee,kBlack);
   makeHistNice(proj_recULS_Ptee,kBlack);
-  makeHistNice(proj_recULS_DCA,kBlack);
-  // makeHistNice(proj_recULS_MeePrim,kBlue+1);
-  // makeHistNice(proj_recULS_PteePrim,kBlue+1);
-  // makeHistNice(proj_recULS_MeeCC,kRed+2);
-  // makeHistNice(proj_recULS_PteeCC,kRed+2);
-  // makeHistNice(proj_recULS_MeeBB,kMagenta+1);
-  // makeHistNice(proj_recULS_PteeBB,kMagenta+1);
+
 
   makeHistNice(proj_recLS_Mee,kRed+2);
   makeHistNice(proj_recLS_Ptee,kRed+2);
-  makeHistNice(proj_recLS_DCA,kRed+2);
-
-
-  // makeHistNice(proj_genLS_MeePrim,kBlue+1);
-  // makeHistNice(proj_genLS_PteePrim,kBlue+1);
-  // makeHistNice(proj_genLS_MeeCC,kRed+2);
-  // makeHistNice(proj_genLS_PteeCC,kRed+2);
-  // makeHistNice(proj_genLS_MeeBB,kMagenta+1);
-  // makeHistNice(proj_genLS_PteeBB,kMagenta+1);
 
 
 
@@ -1867,12 +1404,6 @@ if (bPlotTrackContamination) {
   // legLFCCBB->AddEntry(ptEffEleCC,"charm #rightarrow e","p");
   // legLFCCBB->AddEntry(ptEffEleBB,"beauty #rightarrow e","p");
 
-  auto legTrackPosEle_top = new TLegend(legPosTrack[0]+0.05,legPosTrack[1],legPosTrack[2]+0.05,legPosTrack[3]);
-  legTrackPosEle_top->SetBorderSize(0);
-  legTrackPosEle_top->SetFillStyle(0);
-  legTrackPosEle_top->SetTextSize(0.04);
-  legTrackPosEle_top->AddEntry(ptEffEle,"electrons","p");
-  legTrackPosEle_top->AddEntry(ptEffPos,"positrons","p");
 
   auto legEff_GenGenSmear = new TLegend(legPosTrack[0]+0.05,legPosTrack[1]+0.05,legPosTrack[2]+0.05,legPosTrack[3]);
   legEff_GenGenSmear->SetBorderSize(0);
@@ -1893,12 +1424,25 @@ if (bPlotTrackContamination) {
   legEff_Gen_woPID->SetTextSize(0.04);
   legEff_Gen_woPID->AddEntry(ptEffElePosGen_woPID,"rec/gen wo PID","p");
 
+  auto legEff_PreShower = new TLegend(0.2,0.8,0.5,0.9);
+  legEff_PreShower->SetBorderSize(0);
+  legEff_PreShower->SetFillStyle(0);
+  legEff_PreShower->SetTextSize(0.04);
+  legEff_PreShower->AddEntry(ptEffElePos_PreShower,"rec/gen","p");
+  legEff_PreShower->AddEntry(funcPSparam,"PS eff fit","l");
 
-  auto legTrackEle_top = new TLegend(legPosTrack[0]+0.05,legPosTrack[1],legPosTrack[2]+0.05,legPosTrack[3]);
-  legTrackEle_top->SetBorderSize(0);
-  legTrackEle_top->SetFillStyle(0);
-  legTrackEle_top->SetTextSize(0.04);
-  legTrackEle_top->AddEntry(ptEffEle,"electrons","p");
+  // auto legEff_LF_afterPF = new TLegend(0.6,0.8,0.9,0.9);
+  // legEff_LF_afterPF->SetBorderSize(0);
+  // legEff_LF_afterPF->SetFillStyle(0);
+  // legEff_LF_afterPF->SetTextSize(0.04);
+  // legEff_LF_afterPF->AddEntry(ptEffElePos_LF_afterPF,"LF efficiency ","p");
+
+  auto legEff_HF_afterPF = new TLegend(0.6,0.8,0.9,0.9);
+  legEff_HF_afterPF->SetBorderSize(0);
+  legEff_HF_afterPF->SetFillStyle(0);
+  legEff_HF_afterPF->SetTextSize(0.04);
+  legEff_HF_afterPF->AddEntry(ptEffElePos_HF_afterPF,"HF efficiency ","p");
+
 
   auto legChPionPt = new TLegend(legPosTrack[0]-0.05,legPosTrack[1],legPosTrack[2]+0.05,legPosTrack[3]);
   legChPionPt->SetBorderSize(0);
@@ -1956,11 +1500,6 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   legSigCBHFtoee->AddEntry(hCocktailCCtoee,"cocktail cc #rightarrow ee","l");
   legSigCBHFtoee->AddEntry(hCocktailBBtoee,"cocktail bb #rightarrow ee","l");
 
-  auto legTrackPos_top = new TLegend(legPosTrack[0]+0.05,legPosTrack[1],legPosTrack[2]+0.05,legPosTrack[3]);
-  legTrackPos_top->SetBorderSize(0);
-  legTrackPos_top->SetFillStyle(0);
-  legTrackPos_top->SetTextSize(0.04);
-  legTrackPos_top->AddEntry(ptEffPos,"positrons","p");
 
   auto legTrackPi0LFHF = new TLegend(legPosTrack[0],legPosTrack[1]-0.1,legPosTrack[2]+0.05,legPosTrack[3]);
   legTrackPi0LFHF->SetBorderSize(0);
@@ -2000,20 +1539,6 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   legTrackLFtoeeHFtoe->AddEntry(proj_recLS_LFtoee_Mee,"LS, both legs from LF","p");
   legTrackLFtoeeHFtoe->AddEntry(proj_recLS_HFtoe_Mee,"LS, at least one HF leg","p");
 
-  auto legGenRecPos_top = new TLegend(legPosTrack[0]+0.05,legPosTrack[1],legPosTrack[2]+0.05,legPosTrack[3]);
-  legGenRecPos_top->SetBorderSize(0);
-  legGenRecPos_top->SetFillStyle(0);
-  legGenRecPos_top->SetTextSize(0.04);
-  legGenRecPos_top->AddEntry(ptGenTrackPos,"gen positrons","p");
-  legGenRecPos_top->AddEntry(ptRecTrackPos_rebin,"rec positrons","p");
-
-  auto legGenRecEle_top = new TLegend(legPosTrack[0]+0.05,legPosTrack[1],legPosTrack[2]+0.05,legPosTrack[3]);
-  legGenRecEle_top->SetBorderSize(0);
-  legGenRecEle_top->SetFillStyle(0);
-  legGenRecEle_top->SetTextSize(0.04);
-  legGenRecEle_top->AddEntry(ptGenTrackEle_rebin,"gen electrons","p");
-  legGenRecEle_top->AddEntry(ptRecTrackEle_rebin,"rec electrons","p");
-
   auto legGenGenSmearRecElePos_top = new TLegend(legPosTrack[0]+0.05,legPosTrack[1],legPosTrack[2]+0.05,legPosTrack[3]);
   legGenGenSmearRecElePos_top->SetBorderSize(0);
   legGenGenSmearRecElePos_top->SetFillStyle(0);
@@ -2038,15 +1563,6 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   // legEffULSPair->SetFillStyle(0);
   // legEffULSPair->AddEntry(ptPairEffULS,"ULS pair efficiency","p");
 
-  TLegend* legContamination;
-  legContamination = new TLegend(0.48,0.73,0.83,0.95);
-  legContamination->SetBorderSize(0);
-  legContamination->SetFillStyle(0);
-  legContamination->SetTextSize(0.04);
-  // legContamination->AddEntry(hPurityRecPtNeg,"neg purity","p");
-  // legContamination->AddEntry(hPurityRecPtPos,"pos purity","p");
-  legContamination->AddEntry(hPureContaminationRecPtNeg,"neg","p");
-  legContamination->AddEntry(hPureContaminationRecPtPos,"pos","p");
 
   TLegend* legPIDContamination;
   // legPIDContamination = new TLegend(legPosCont[0]-0.05,legPosCont[1],legPosCont[2],legPosCont[3]);
@@ -2059,8 +1575,9 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   legPIDContamination->AddEntry(hTotalPureContaminationRecPt,"Total","p");
   legPIDContamination->AddEntry(hMuonContaminationRecPt,"Muon","p");
   legPIDContamination->AddEntry(hPionContaminationRecPt,"Pion","p");
-  // legPIDContamination->AddEntry(hKaonContaminationRecPt,"Kaon","p");
-  // legPIDContamination->AddEntry(hProtonContaminationRecPt,"Proton","p");
+  legPIDContamination->AddEntry(hKaonContaminationRecPt,"Kaon","p");
+  legPIDContamination->AddEntry(hProtonContaminationRecPt,"Protonn","p");
+
 
   TLegend* legRejFactor;
   legRejFactor = new TLegend(0.7,0.8,0.9,0.9);
@@ -2134,13 +1651,7 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   legSmearLabel->AddEntry(ptRecTrackAfterSmearing_rebin,"after Smearing","p");
   legSmearLabel->AddEntry(ptRecTrackAfterKineCuts_rebin,"after kine Cuts","p");
   legSmearLabel->AddEntry(ptRecTrackElePos_rebin,"after PID cuts","p");
-  // legSmearLabel->AddEntry(etaRecTrackEtaCut_1," |#eta| < 1.0","p");
-  // legSmearLabel->AddEntry(etaRecTrackEtaCut_2," |#eta| < 2.0","p");
-  // legSmearLabel->AddEntry(etaRecTrackEtaCut_4," |#eta| < 4.0","p");
-  // legSmearLabel->AddEntry(etaRecTrackEtaCut_5," |#eta| < 5.0","p");
-  // legSmearLabel->AddEntry(etaRecTrackEtaCut_6," |#eta| < 6.0","p");
-  // legSmearLabel->AddEntry(etaRecTrackEtaCut_8," |#eta| < 8.0","p");
-  // legSmearLabel->AddEntry(etaRecTrackEtaCut_10," |#eta| < 10.0","p");
+
 
 
 
@@ -2339,6 +1850,24 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   // phiGenTrackPrim->Draw("pe1 same");
   // cKineGen->SaveAs("./plots/GenPtEtaPhi.png");
 
+  // auto cTrackPFVectorPt = new TCanvas("cTrackPFVectorPt","cTrackPFVectorPt",800,800);
+  // cTrackPFVectorPt->SetLogy();
+  // cTrackPFVectorPt->SetTopMargin(0.03);
+  // cTrackPFVectorPt->SetRightMargin(0.03);
+  // cTrackPFVectorPt->SetLeftMargin(0.13);
+  // makeHistNice(hTracks_ElePos_Gen_inPFvector_Pt,kBlack);
+  // makeHistNice(hTracks_ElePos_Rec_inPFvector_Pt,kRed);
+  //
+  // hTracks_ElePos_Rec_inPFvector_Pt->GetYaxis()->SetTitle("N Tracks");
+  // hTracks_ElePos_Rec_inPFvector_Pt->GetXaxis()->SetTitle("#it{p}_{T} (GeV/#it{c})");
+  // hTracks_ElePos_Rec_inPFvector_Pt->GetXaxis()->SetRangeUser(0.0,0.5);
+  // hTracks_ElePos_Gen_inPFvector_Pt->Scale(1.,"width");
+  // hTracks_ElePos_Rec_inPFvector_Pt->Scale(1.,"width");
+  // hTracks_ElePos_Rec_inPFvector_Pt->Draw("hist p e1 ");
+  // hTracks_ElePos_Gen_inPFvector_Pt->Draw("hist p e1 same");
+  //
+  // cTrackPFVectorPt->SaveAs("./plots/PtTrack_prefilterVec_GenRec.png");
+
 
   if(bPlotLFHFcontributions) {
     // Plot single electrons from HF as function of pt, compaere cocktail, my study and paper
@@ -2466,14 +1995,14 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     ptRecTrackElePos_rebin->SetLineColor(kBlue+1);
     ptRecTrackElePos_rebin->SetMarkerColor(kBlue+1);
 
-    auto cMeePteeDCACharmBeautyHFtoe = new TCanvas("cMeePteeDCACharmBeautyHFtoe","cMeePteeDCACharmBeautyHFtoe",1350,600);
-    cMeePteeDCACharmBeautyHFtoe->Divide(3,1);
+    auto cMeePteeCharmBeautyHFtoe = new TCanvas("cMeePteeCharmBeautyHFtoe","cMeePteeCharmBeautyHFtoe",1350,600);
+    cMeePteeCharmBeautyHFtoe->Divide(2,1);
     for (size_t i = 1; i < 4; i++) {
-      cMeePteeDCACharmBeautyHFtoe->cd(i)->SetTopMargin(0.03);
-      cMeePteeDCACharmBeautyHFtoe->cd(i)->SetRightMargin(0.03);
+      cMeePteeCharmBeautyHFtoe->cd(i)->SetTopMargin(0.03);
+      cMeePteeCharmBeautyHFtoe->cd(i)->SetRightMargin(0.03);
     }
-    cMeePteeDCACharmBeautyHFtoe->cd(1);
-    cMeePteeDCACharmBeautyHFtoe->cd(1)->SetLogy();
+    cMeePteeCharmBeautyHFtoe->cd(1);
+    cMeePteeCharmBeautyHFtoe->cd(1)->SetLogy();
     proj_recLS_HFtoe_Mee->GetYaxis()->SetTitleOffset(1.);
     proj_recLS_HFtoe_Mee->GetYaxis()->SetTitle("1/N_{ev}d^{2}N_{X->e}/dm_{ee}dy");
     proj_recLS_HFtoe_Mee->GetXaxis()->SetTitle("#it{m}_{ee} (GeV/#it{c}^{2})");
@@ -2482,8 +2011,8 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     proj_recLS_Btoe_Mee->Draw("hist p e1 same");
     legTrackLFHFtoe->Draw("same");
 
-    cMeePteeDCACharmBeautyHFtoe->cd(2);
-    cMeePteeDCACharmBeautyHFtoe->cd(2)->SetLogy();
+    cMeePteeCharmBeautyHFtoe->cd(2);
+    cMeePteeCharmBeautyHFtoe->cd(2)->SetLogy();
     proj_recLS_HFtoe_Ptee->GetYaxis()->SetTitleOffset(1.);
     proj_recLS_HFtoe_Ptee->GetYaxis()->SetTitle("1/N_{ev}d^{2}N_{X->e}/d#it{p}_{T,ee}dy");
     proj_recLS_HFtoe_Ptee->GetXaxis()->SetTitle("#it{p}_{T,ee} (GeV/#it{c})");
@@ -2492,28 +2021,19 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     proj_recLS_Ctoe_Ptee->Draw("hist p e1 same");
     proj_recLS_Btoe_Ptee->Draw("hist p e1 same");
 
-    cMeePteeDCACharmBeautyHFtoe->cd(3);
-    cMeePteeDCACharmBeautyHFtoe->cd(3)->SetLogy();
-    proj_recLS_HFtoe_DCA->GetYaxis()->SetTitleOffset(1.);
-    proj_recLS_HFtoe_DCA->GetYaxis()->SetTitle("1/N_{ev}d^{2}N_{X->e}/dDCAdy");
-    proj_recLS_HFtoe_DCA->GetXaxis()->SetTitle("DCA (cm)");
-    proj_recLS_HFtoe_DCA->Draw("hist p e1");
-    proj_recLS_Ctoe_DCA->Draw("hist p e1 same");
-    proj_recLS_Btoe_DCA->Draw("hist p e1 same");
-
-    cMeePteeDCACharmBeautyHFtoe->SaveAs("./plots/MeePteeDCA_CharmBeautyHFtoe.png");
+    cMeePteeCharmBeautyHFtoe->SaveAs("./plots/MeePtee_CharmBeautyHFtoe.png");
 
 
 
-    auto cMeePteeDCACharmBeautyHFtoee = new TCanvas("cMeePteeDCACharmBeautyHFtoee","cMeePteeDCACharmBeautyHFtoee",1350,600);
-    cMeePteeDCACharmBeautyHFtoee->SetLogy();
-    cMeePteeDCACharmBeautyHFtoee->Divide(3,1);
+    auto cMeePteeCharmBeautyHFtoee = new TCanvas("cMeePteeCharmBeautyHFtoee","cMeePteeCharmBeautyHFtoee",1350,600);
+    cMeePteeCharmBeautyHFtoee->SetLogy();
+    cMeePteeCharmBeautyHFtoee->Divide(2,1);
     for (size_t i = 1; i < 4; i++) {
-      cMeePteeDCACharmBeautyHFtoee->cd(i)->SetTopMargin(0.03);
-      cMeePteeDCACharmBeautyHFtoee->cd(i)->SetRightMargin(0.03);
+      cMeePteeCharmBeautyHFtoee->cd(i)->SetTopMargin(0.03);
+      cMeePteeCharmBeautyHFtoee->cd(i)->SetRightMargin(0.03);
     }
-    cMeePteeDCACharmBeautyHFtoee->cd(1);
-    cMeePteeDCACharmBeautyHFtoee->cd(1)->SetLogy();
+    cMeePteeCharmBeautyHFtoee->cd(1);
+    cMeePteeCharmBeautyHFtoee->cd(1)->SetLogy();
     proj_recLS_LFtoee_Mee->GetYaxis()->SetTitleOffset(1.);
     proj_recLS_LFtoee_Mee->GetYaxis()->SetTitle("1/N_{ev}d^{2}N_{X->ee}/dm_{ee}dy");
     proj_recLS_LFtoee_Mee->GetXaxis()->SetTitle("#it{m}_{ee} (GeV/#it{c}^{2})");
@@ -2521,8 +2041,8 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     proj_recLS_HFtoee_Mee->Draw("hist p e1 same");
     legTrackLFHFtoee->Draw("same");
 
-    cMeePteeDCACharmBeautyHFtoee->cd(2);
-    cMeePteeDCACharmBeautyHFtoee->cd(2)->SetLogy();
+    cMeePteeCharmBeautyHFtoee->cd(2);
+    cMeePteeCharmBeautyHFtoee->cd(2)->SetLogy();
     proj_recLS_LFtoee_Ptee->GetYaxis()->SetTitleOffset(1.);
     proj_recLS_LFtoee_Ptee->GetYaxis()->SetTitle("1/N_{ev}d^{2}N_{X->ee}/d#it{p}_{T,ee}dy");
     proj_recLS_LFtoee_Ptee->GetXaxis()->SetTitle("#it{p}_{T,ee} (GeV/#it{c})");
@@ -2530,27 +2050,19 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     proj_recLS_LFtoee_Ptee->Draw("hist p e1");
     proj_recLS_HFtoee_Ptee->Draw("hist p e1 same");
 
-    cMeePteeDCACharmBeautyHFtoee->cd(3);
-    cMeePteeDCACharmBeautyHFtoee->cd(3)->SetLogy();
-    proj_recLS_LFtoee_DCA->GetYaxis()->SetTitleOffset(1.);
-    proj_recLS_LFtoee_DCA->GetYaxis()->SetTitle("1/N_{ev}d^{2}N_{X->ee}/dDCAdy");
-    proj_recLS_LFtoee_DCA->GetXaxis()->SetTitle("DCA (cm)");
-    proj_recLS_LFtoee_DCA->Draw("hist p e1");
-    proj_recLS_HFtoee_DCA->Draw("hist p e1 same");
-
-    cMeePteeDCACharmBeautyHFtoee->SaveAs("./plots/MeePteeDCA_LFHFtoee.png");
+    cMeePteeCharmBeautyHFtoee->SaveAs("./plots/MeePtee_LFHFtoee.png");
 
 
 
-    auto cMeePteeDCALFtoeeHFtoe = new TCanvas("cMeePteeDCALFtoeeHFtoe","cMeePteeDCALFtoeeHFtoe",1350,600);
-    cMeePteeDCALFtoeeHFtoe->SetLogy();
-    cMeePteeDCALFtoeeHFtoe->Divide(3,1);
+    auto cMeePteeLFtoeeHFtoe = new TCanvas("cMeePteeLFtoeeHFtoe","cMeePteeLFtoeeHFtoe",1350,600);
+    cMeePteeLFtoeeHFtoe->SetLogy();
+    cMeePteeLFtoeeHFtoe->Divide(2,1);
     for (size_t i = 1; i < 4; i++) {
-      cMeePteeDCALFtoeeHFtoe->cd(i)->SetTopMargin(0.03);
-      cMeePteeDCALFtoeeHFtoe->cd(i)->SetRightMargin(0.03);
+      cMeePteeLFtoeeHFtoe->cd(i)->SetTopMargin(0.03);
+      cMeePteeLFtoeeHFtoe->cd(i)->SetRightMargin(0.03);
     }
-    cMeePteeDCALFtoeeHFtoe->cd(1);
-    cMeePteeDCALFtoeeHFtoe->cd(1)->SetLogy();
+    cMeePteeLFtoeeHFtoe->cd(1);
+    cMeePteeLFtoeeHFtoe->cd(1)->SetLogy();
     proj_recLS_MCpidEle_Mee->GetYaxis()->SetTitleOffset(1.);
     proj_recLS_MCpidEle_Mee->GetYaxis()->SetTitle("1/N_{ev}d^{2}N_{X->ee}/dm_{ee}dy");
     proj_recLS_MCpidEle_Mee->GetXaxis()->SetTitle("#it{m}_{ee} (GeV/#it{c}^{2})");
@@ -2559,8 +2071,8 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     proj_recLS_HFtoe_Mee->Draw("hist p e1 same");
     legTrackLFtoeeHFtoe->Draw("same");
 
-    cMeePteeDCALFtoeeHFtoe->cd(2);
-    cMeePteeDCALFtoeeHFtoe->cd(2)->SetLogy();
+    cMeePteeLFtoeeHFtoe->cd(2);
+    cMeePteeLFtoeeHFtoe->cd(2)->SetLogy();
     proj_recLS_MCpidEle_Ptee->GetYaxis()->SetTitleOffset(1.);
     proj_recLS_MCpidEle_Ptee->GetYaxis()->SetTitle("1/N_{ev}d^{2}N_{X->ee}/d#it{p}_{T,ee}dy");
     proj_recLS_MCpidEle_Ptee->GetXaxis()->SetTitle("#it{p}_{T,ee} (GeV/#it{c})");
@@ -2569,39 +2081,65 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     proj_recLS_LFtoee_Ptee->Draw("hist p e1 same");
     proj_recLS_HFtoe_Ptee->Draw("hist p e1 same");
 
-    cMeePteeDCALFtoeeHFtoe->cd(3);
-    cMeePteeDCALFtoeeHFtoe->cd(3)->SetLogy();
-    proj_recLS_MCpidEle_DCA->GetYaxis()->SetTitleOffset(1.);
-    proj_recLS_MCpidEle_DCA->GetYaxis()->SetTitle("1/N_{ev}d^{2}N_{X->ee}/dDCAdy");
-    proj_recLS_MCpidEle_DCA->GetXaxis()->SetTitle("DCA (cm)");
-    proj_recLS_MCpidEle_DCA->Draw("hist p e1");
-    proj_recLS_LFtoee_DCA->Draw("hist p e1 same");
-    proj_recLS_HFtoe_DCA->Draw("hist p e1 same");
+    cMeePteeLFtoeeHFtoe->SaveAs("./plots/MeePtee_LFtoeeHFtoe.png");
 
-    // cMeePteeDCALFtoeeHFtoe->SaveAs("./plots/MeePteeDCA_LFtoeeHFtoe.png");
+    // auto cPF_opAngle_mass = new TCanvas("cTrackPFVectorPt","cTrackPFVectorPt",1900,800);
+    // cPF_opAngle_mass->Divide(2,1);
+    // for (size_t i = 1; i < 4; i++) {
+    //   cPF_opAngle_mass->cd(i)->SetTopMargin(0.03);
+    //   cPF_opAngle_mass->cd(i)->SetRightMargin(0.03);
+    // }
+    // cPF_opAngle_mass->cd(1);
+    // cPF_opAngle_mass->cd(1)->SetLogz();
+    // makeHistNiceTH2(hMeeOpAngle_RecULS_bPF,kBlack);
+    // makeHistNiceTH2(hMeeOpAngle_RecULS_aPF,kBlack);
+    // hMeeOpAngle_RecULS_bPF->GetYaxis()->SetTitleOffset(1.);
+    // hMeeOpAngle_RecULS_bPF->GetYaxis()->SetTitle("opening angle (mrad)");
+    // hMeeOpAngle_RecULS_bPF->GetXaxis()->SetTitle("#it{m}_{ee} (GeV/#it{c}^{2})");
+    // hMeeOpAngle_RecULS_bPF->GetXaxis()->SetRangeUser(0.0,0.15);
+    // hMeeOpAngle_RecULS_bPF->Draw("colz");
+    // cPF_opAngle_mass->cd(2);
+    // cPF_opAngle_mass->cd(2)->SetLogz();
+    // hMeeOpAngle_RecULS_aPF->GetYaxis()->SetTitleOffset(1.);
+    // hMeeOpAngle_RecULS_aPF->GetYaxis()->SetTitle("opening angle (mrad)");
+    // hMeeOpAngle_RecULS_aPF->GetXaxis()->SetTitle("#it{m}_{ee} (GeV/#it{c}^{2})");
+    // hMeeOpAngle_RecULS_aPF->GetXaxis()->SetRangeUser(0.0,0.15);
+    // hMeeOpAngle_RecULS_aPF->Draw("colz");
+    // // cPF_opAngle_mass->SaveAs(Form("./plots/PF_BeforeAfter_opAngle_Mass_sce%i.root",ith_PIDscenario);
 
-    // generate root file with LS background mee ptee and dca LF->ee , HF->e and Sum
+
+    // generate root file with LS background mee ptee and  LF->ee , HF->e and Sum
     if (bGenerateBackground) {
-      TFile *fBackground_weigths = TFile::Open("./plots/MeePteeDCA_LFtoeeHFtoe_noweight.root","RECREATE");
+      // TFile *fBackground_weigths = TFile::Open("./plots/MeePtee_LFtoeeHFtoe_noweight.root","RECREATE");
+      TFile *fBackground_weigths = TFile::Open(Form("./plots/plottingMacros/MeePtee_recLS_wPreFilter_sce%i.root",ith_PIDscenario),"RECREATE");
       proj_recLS_MCpidEle_Mee->SetName("proj_recLS_MCpidEle_Mee");
       proj_recLS_LFtoee_Mee->SetName("proj_recLS_LFtoee_Mee");
       proj_recLS_HFtoe_Mee->SetName("proj_recLS_HFtoe_Mee");
+      proj_recLS_HFtoee_Mee->SetName("proj_recLS_HFtoee_Mee");
       proj_recLS_MCpidEle_Ptee->SetName("proj_recLS_MCpidEle_Ptee");
       proj_recLS_LFtoee_Ptee->SetName("proj_recLS_LFtoee_Ptee");
       proj_recLS_HFtoe_Ptee->SetName("proj_recLS_HFtoe_Ptee");
+      proj_recLS_HFtoee_Ptee->SetName("proj_recLS_HFtoee_Ptee");
       proj_recLS_MCpidEle_Mee->SetMarkerStyle(24);
       proj_recLS_LFtoee_Mee->SetMarkerStyle(24);
       proj_recLS_HFtoe_Mee->SetMarkerStyle(24);
+      proj_recLS_HFtoee_Mee->SetMarkerStyle(24);
       proj_recLS_MCpidEle_Ptee->SetMarkerStyle(24);
       proj_recLS_LFtoee_Ptee->SetMarkerStyle(24);
       proj_recLS_HFtoe_Ptee->SetMarkerStyle(24);
+      proj_recLS_HFtoee_Ptee->SetMarkerStyle(24);
       proj_recLS_MCpidEle_Mee->Write();
       proj_recLS_LFtoee_Mee->Write();
       proj_recLS_HFtoe_Mee->Write();
+      proj_recLS_HFtoee_Mee->Write();
       proj_recLS_MCpidEle_Ptee->Write();
       proj_recLS_LFtoee_Ptee->Write();
       proj_recLS_HFtoe_Ptee->Write();
+      proj_recLS_HFtoee_Ptee->Write();
+      // hMeeOpAngle_RecULS_bPF->Write("beforePF_opAngle_mass");
+      // hMeeOpAngle_RecULS_aPF->Write("afterPF_opAngle_mass");
       fBackground_weigths->Close();
+      printf(" MeePtee_recLS_wPreFilter_sce%i has been written. \n", ith_PIDscenario);
     }
 
 
@@ -2731,38 +2269,6 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
 
 
   if (bPlotEfficiency) {
-    auto cEffElePt = new TCanvas("cEffElePt","cEffElePt",800,800);
-    // cEffElePt->SetLogy();
-    cEffElePt->SetTopMargin(0.03);
-    cEffElePt->SetRightMargin(0.03);
-    cEffElePt->SetLeftMargin(0.13);
-    ptEffEle->GetYaxis()->SetTitle("#it{p}_{T}^{rec}/#it{p}_{T}^{gen}");
-    ptEffEle->GetXaxis()->SetTitle("#it{p}_{T} (GeV/#it{c})");
-    ptEffEle->GetXaxis()->SetRangeUser(0.0,4.0);
-    ptEffEle->Draw("hist p e1 ");
-    // // ptEffElePrim->SetMaximum(1.);
-    // ptEffElePrim->Draw("hist p ");
-    // ptEffEleCC->Draw("hist p same");
-    // ptEffEleBB->Draw("hist p same");
-    legTrackEle_top->Draw("same");
-    cEffElePt->SaveAs("./plots/EffElePt.png");
-
-    auto cEffElePosPt = new TCanvas("cEffElePosPt","cEffElePosPt",800,800);
-    // cEffElePosPt->SetLogy();
-    cEffElePosPt->SetTopMargin(0.03);
-    cEffElePosPt->SetRightMargin(0.03);
-    cEffElePosPt->SetLeftMargin(0.13);
-    ptEffEle->GetYaxis()->SetTitle("#it{p}_{T}^{rec}/#it{p}_{T}^{gen}");
-    ptEffEle->GetXaxis()->SetTitle("#it{p}_{T} (GeV/#it{c})");
-    ptEffEle->GetXaxis()->SetRangeUser(0.0,4.0);
-    ptEffEle->SetMaximum(1.1*std::max({ptEffEle->GetMaximum(),ptEffPos->GetMaximum()}));
-    ptEffEle->SetMinimum(0.);
-    ptEffEle->Draw("hist p e1 ");
-    ptEffPos->Draw("hist p e1 same");
-    legTrackPosEle_top->Draw("same");
-    textBField->Draw("same");
-    textPIDScenario->Draw("same");
-    cEffElePosPt->SaveAs("./plots/Eff_ElePos_Pt.png");
 
     auto cEffAddedElePosPt = new TCanvas("cEffAddedElePosPt","cEffAddedElePosPt",800,800);
     // cEffAddedElePosPt->SetLogy();
@@ -2776,94 +2282,43 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     ptEffElePosGen->SetMaximum(1.1*std::max({ptEffElePosGen->GetMaximum(),ptEffElePosGenSmeared->GetMaximum()}));
     // ptEffElePosGen->SetMaximum(1.1*std::max({ptEffElePosGen->GetMaximum()}));
     // ptEffElePosGenSmeared->SetMaximum(1.1*std::max({ptEffElePosGenSmeared->GetMaximum()}));
-    ptEffElePosGen->SetMinimum(0.);
+    // ptEffElePosGen->SetMinimum(0.);
+    // ptEffElePosGen->GetYaxis()->SetRangeUser(0.,1.);
     ptEffElePosGen->Draw("hist p e1");
     ptEffElePosGenSmeared->Draw("hist p e1 same");
     legEff_GenGenSmear->Draw("same");
     textBField->Draw("same");
     // textPIDScenario->Draw("same");
     cEffAddedElePosPt->SaveAs("./plots/Eff_ElePos_Pt_GenGenSmear.png");
+    ptEffElePosGen->GetYaxis()->SetRangeUser(0.,1.);
     ptEffElePosGen->Draw("hist p e1 ");
     legEff_Gen->Draw("same");
     textBField->Draw("same");
-    textPIDScenario->Draw("same");
+    // textPIDScenario->Draw("same");
     cEffAddedElePosPt->SaveAs("./plots/Eff_ElePos_Pt_Gen.png");
     ptEffElePosGen_woPID->Draw("hist p e1 ");
     legEff_Gen_woPID->Draw("same");
     textBField->Draw("same");
-    textPIDScenario->Draw("same");
+    // textPIDScenario->Draw("same");
     cEffAddedElePosPt->SaveAs("./plots/Eff_ElePos_Pt_Gen_woPID.png");
-    ptEffElePOS_PreShower->Draw("hist p e1");
+    ptEffElePos_PreShower->GetYaxis()->SetRangeUser(0.,1.);
+    ptEffElePos_PreShower->Draw("hist p e1");
+    ptEffElePos_PreShower->GetYaxis()->SetTitle("#it{p}_{T}^{rec}/#it{p}_{T}^{gen}");
+    ptEffElePos_PreShower->GetXaxis()->SetTitle("#it{p}_{T} (GeV/#it{c})");
+    funcPSparam->Draw("same");
+    legEff_PreShower->Draw("same");
     cEffAddedElePosPt->SaveAs("./plots/Eff_ElePos_Pt_PreShower.png");
+    // ptEffElePos_LF_afterPF->GetXaxis()->SetRangeUser(0.,4.);
+    // ptEffElePos_LF_afterPF->GetYaxis()->SetTitle("#it{p}_{T}^{rec}/#it{p}_{T}^{gen}");
+    // ptEffElePos_LF_afterPF->Draw("hist p e1");
+    // legEff_LF_afterPF->Draw("same");
+    cEffAddedElePosPt->SaveAs("./plots/Eff_ElePos_Pt_LF_afterPF.png");
+    ptEffElePos_HF_afterPF->GetXaxis()->SetRangeUser(0.,4.);
+    ptEffElePos_HF_afterPF->GetYaxis()->SetTitle("#it{p}_{T}^{rec}/#it{p}_{T}^{gen}");
+    ptEffElePos_HF_afterPF->Draw("hist p e1");
+    legEff_HF_afterPF->Draw("same");
+    cEffAddedElePosPt->SaveAs("./plots/Eff_ElePos_Pt_HF_afterPF.png");
 
-
-    auto cEffEleEta = new TCanvas("cEffEleEta","cEffEleEta",800,800);
-    // cEffEleEta->SetLogy();
-    cEffEleEta->SetTopMargin(0.03);
-    cEffEleEta->SetRightMargin(0.03);
-    cEffEleEta->SetLeftMargin(0.13);
-    etaEffEle->GetYaxis()->SetTitle("#eta^{rec}/#eta^{gen}");
-    etaEffEle->GetXaxis()->SetTitle("#eta");
-    etaEffEle->GetXaxis()->SetRangeUser(-2.0,2.0);
-    etaEffEle->Draw("hist p e1 ");
-    // // etaEffElePrim->SetMaximum(1.);
-    // etaEffElePrim->Draw("hist p");
-    // etaEffEleCC->Draw("hist p same");
-    // etaEffEleBB->Draw("hist p same");
-    legTrackEle_top->Draw("same");
-    cEffEleEta->SaveAs("./plots/EffEleEta.png");
-
-    auto cEffElePhi = new TCanvas("cEffElePhi","cEffElePhi",800,800);
-    // cEffElePhi->SetLogy();
-    cEffElePhi->SetTopMargin(0.03);
-    cEffElePhi->SetRightMargin(0.03);
-    cEffElePhi->SetLeftMargin(0.13);
-    phiEffEle->GetYaxis()->SetTitle("#varphi^{rec}/#varphi^{gen}");
-    phiEffEle->GetXaxis()->SetTitle("#varphi (rad)");
-    phiEffEle->Draw("hist p e1 ");
-    // // phiEffElePrim->SetMaximum(1.);
-    // phiEffElePrim->GetXaxis()->SetRangeUser(-7.0,7.0);
-    // phiEffElePrim->Draw("hist p ");
-    // phiEffEleCC->Draw("hist p same");
-    // phiEffEleBB->Draw("hist p same");
-    legTrackEle_top->Draw("same");
-    cEffElePhi->SaveAs("./plots/EffElePhi.png");
-
-
-    auto cEffPosElePtEtaPhi = new TCanvas("cEffPosElePtEtaPhi","cEffPosElePtEtaPhi",1350,600);
-    cEffPosElePtEtaPhi->Divide(3,1);
-    for (size_t i = 1; i < 4; i++) {
-      cEffPosElePtEtaPhi->cd(i)->SetTopMargin(0.03);
-      cEffPosElePtEtaPhi->cd(i)->SetRightMargin(0.03);
-    }
-    cEffPosElePtEtaPhi->cd(1);
-    ptEffEle->GetYaxis()->SetTitle("#it{p}_{T}^{rec}/#it{p}_{T}^{gen}");
-    ptEffPos->GetYaxis()->SetTitle("#it{p}_{T}^{rec}/#it{p}_{T}^{gen}");
-    ptEffEle->GetXaxis()->SetTitle("#it{p}_{T} (GeV/#it{c})");
-    ptEffEle->GetXaxis()->SetRangeUser(0.0,4.0);
-    ptEffPos->GetXaxis()->SetRangeUser(0.0,4.0);
-    ptEffEle->SetMaximum(1.1*std::max({ptEffEle->GetMaximum(),ptEffPos->GetMaximum()}));
-    ptEffEle->SetMinimum(0.);
-    ptEffEle->Draw("hist p e1");
-    ptEffPos->Draw("same hist p e1");
-    legTrackPosEle_top->Draw("same");
-    cEffPosElePtEtaPhi->cd(2);
-    etaEffEle->GetYaxis()->SetTitle("#eta^{rec}/#eta^{gen}");
-    etaEffEle->GetXaxis()->SetTitle("#eta");
-    etaEffEle->GetXaxis()->SetRangeUser(-2.0,2.0);
-    etaEffEle->SetMaximum(1.1*std::max({etaEffEle->GetMaximum(),etaEffPos->GetMaximum()}));
-    etaEffEle->SetMinimum(0.);
-    etaEffEle->Draw("hist p e1");
-    etaEffPos->Draw("same hist p e1");
-    cEffPosElePtEtaPhi->cd(3);
-    phiEffEle->GetYaxis()->SetTitle("#varphi^{rec}/#varphi^{gen}");
-    phiEffEle->GetXaxis()->SetTitle("#varphi (rad)");
-    phiEffEle->SetMaximum(1.1*std::max({phiEffEle->GetMaximum(),phiEffPos->GetMaximum()}));
-    phiEffEle->SetMinimum(0.);
-    phiEffEle->GetXaxis()->SetRangeUser(-7.0,7.0);
-    phiEffEle->Draw("hist p e1");
-    phiEffPos->Draw("same hist p e1");
-    cEffPosElePtEtaPhi->SaveAs("./plots/Eff_ElePos_PtEtaPhi.png");
 
 
     // auto cEffElePtEtaPhi = new TCanvas("cEffElePtEtaPhi","cEffElePtEtaPhi",900,400);
@@ -2940,55 +2395,6 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     // cEffPosPtEtaPhi->SaveAs("./plots/EffPosPtEtaPhi.png");
 
 
-
-    auto cEffPosPt = new TCanvas("cEffPosPt","cEffPosPt",800,800);
-    // cEffPosPt->SetLogy();
-    cEffPosPt->SetTopMargin(0.03);
-    cEffPosPt->SetRightMargin(0.03);
-    cEffPosPt->SetLeftMargin(0.13);
-    ptEffPos->GetYaxis()->SetTitle("#it{p}_{T}^{rec}/#it{p}_{T}^{gen}");
-    ptEffPos->GetXaxis()->SetTitle("#it{p}_{T} (GeV/#it{c})");
-    ptEffPos->GetXaxis()->SetRangeUser(0.0,4.0);
-    ptEffPos->Draw("hist p e1");
-    // ptEffPosPrim->SetMaximum(1.);
-    // ptEffPosPrim->Draw("hist p ");
-    // ptEffPosCC->Draw("hist p same");
-    // ptEffPosBB->Draw("hist p same");
-    legTrackPos_top->Draw("same");
-    cEffPosPt->SaveAs("./plots/EffPosPt.png");
-
-    auto cEffPosEta = new TCanvas("cEffPosEta","cEffPosEta",800,800);
-    // cEffPosEta->SetLogy();
-    cEffPosEta->SetTopMargin(0.03);
-    cEffPosEta->SetRightMargin(0.03);
-    cEffPosEta->SetLeftMargin(0.13);
-    etaEffPos->GetYaxis()->SetTitle("#eta^{rec}/#eta^{gen}");
-    etaEffPos->GetXaxis()->SetTitle("#eta");
-    etaEffPos->GetXaxis()->SetRangeUser(-2.0,2.0);
-    etaEffPos->Draw("hist p e1");
-    // etaEffPosPrim->SetMaximum(1.);
-    // etaEffPosPrim->Draw("hist p ");
-    // etaEffPosCC->Draw("hist p same");
-    // etaEffPosBB->Draw("hist p same");
-    legTrackPos_top->Draw("same");
-    cEffPosEta->SaveAs("./plots/EffPosEta.png");
-
-    auto cEffPosPhi = new TCanvas("cEffPosPhi","cEffPosPhi",800,800);
-    // cEffPosPhi->SetLogy();
-    cEffPosPhi->SetTopMargin(0.03);
-    cEffPosPhi->SetRightMargin(0.03);
-    cEffPosPhi->SetLeftMargin(0.13);
-    phiEffPos->GetYaxis()->SetTitle("#varphi^{rec}/#varphi^{gen}");
-    phiEffPos->GetXaxis()->SetTitle("#varphi (rad)");
-    phiEffPos->Draw("hist p e1");
-    // phiEffPosPrim->SetMaximum(1.);
-    // phiEffPosPrim->GetXaxis()->SetRangeUser(-7.0,7.0);
-    // phiEffPosPrim->Draw("hist p ");
-    // phiEffPosCC->Draw("hist p same");
-    // phiEffPosBB->Draw("hist p same");
-    legTrackPos_top->Draw("same");
-    cEffPosPhi->SaveAs("./plots/EffPosPhi.png");
-
     auto cGenGenSmearRecElePosPt = new TCanvas("cGenGenSmearRecElePosPt","cGenGenSmearRecElePosPt",800,800);
     cGenGenSmearRecElePosPt->SetLogy();
     cGenGenSmearRecElePosPt->SetTopMargin(0.03);
@@ -3020,35 +2426,6 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     ptRecTrackElePos_rebin->Draw("hist p e1 same");
     cGenGenSmearRecElePosPt->SaveAs("./plots/GenGenSmearRecElePos_Pt_0-0.5+woPIDcuts.png");
 
-    auto cGenRecElePt = new TCanvas("cGenRecElePt","cGenRecElePt",800,800);
-    // cGenRecElePt->SetLogy();
-    cGenRecElePt->SetTopMargin(0.03);
-    cGenRecElePt->SetRightMargin(0.03);
-    cGenRecElePt->SetLeftMargin(0.13);
-    ptGenTrackEle_rebin->GetYaxis()->SetTitle("N^{gen} Tracks");
-    ptGenTrackEle_rebin->GetXaxis()->SetTitle("#it{p}_{T} (GeV/#it{c})");
-    ptGenTrackEle_rebin->GetXaxis()->SetRangeUser(0.0,4.0);
-    ptGenTrackEle_rebin->SetMaximum(1.1*std::max({ptGenTrackEle->GetMaximum(),ptRecTrackEle->GetMaximum()}));
-    ptGenTrackEle_rebin->Draw("hist p e1");
-    ptRecTrackEle_rebin->Draw("hist p e1 same");
-    legGenRecEle_top->Draw("same");
-    cGenRecElePt->SaveAs("./plots/GenRecEle_Pt.png");
-
-
-    auto cGenRecPosPt = new TCanvas("cGenRecPosPt","cGenRecPosPt",800,800);
-    // cGenRecPosPt->SetLogy();
-    cGenRecPosPt->SetTopMargin(0.03);
-    cGenRecPosPt->SetRightMargin(0.03);
-    cGenRecPosPt->SetLeftMargin(0.13);
-    ptGenTrackPos_rebin->GetYaxis()->SetTitle("N^{gen} Tracks");
-    ptGenTrackPos_rebin->GetXaxis()->SetTitle("#it{p}_{T} (GeV/#it{c})");
-    ptGenTrackPos_rebin->GetXaxis()->SetRangeUser(0.0,4.0);
-    ptGenTrackPos_rebin->SetMaximum(1.1*std::max({ptGenTrackPos->GetMaximum(),ptRecTrackPos->GetMaximum()}));
-    ptGenTrackPos_rebin->Draw("hist p e1");
-    ptRecTrackPos_rebin->Draw("hist p e1 same");
-    legGenRecPos_top->Draw("same");
-    cGenRecPosPt->SaveAs("./plots/GenRecPos_Pt.png");
-
 
 
     auto cEffElePosPtEta = new TCanvas("cEffElePosPtEta","cEffElePosPtEta",800,800);
@@ -3064,13 +2441,12 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     ptEtaEffElePos->GetZaxis()->SetTitle("track efficiency");
     ptEtaEffElePos->GetZaxis()->SetTitleOffset(1.2);
     ptEtaEffElePos->GetZaxis()->RotateTitle(kTRUE);
-    ptEtaEffElePos->GetXaxis()->SetRangeUser(0.0,4.0);
-    // ptEtaEffElePos->GetXaxis()->SetRangeUser(0.0,0.6);
+    // ptEtaEffElePos->GetXaxis()->SetRangeUser(0.0,4.0);
+    ptEtaEffElePos->GetXaxis()->SetRangeUser(0.0,0.6);
     ptEtaEffElePos->GetYaxis()->SetRangeUser(-1.2,1.8);
     ptEtaEffElePos->GetZaxis()->SetRangeUser(0,1.0);
     ptEtaEffElePos->Draw("Colz");
     legendInfoTrackEff->Draw("same");
-    // legTrackEle_top->Draw("same");
     cEffElePosPtEta->SaveAs("./plots/EffElePosPtEta.png");
 
 
@@ -3091,7 +2467,7 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
 
     auto cPairEffElePosMPt = new TCanvas("cPairEffElePosMPt","cPairEffElePosMPt",800,800);
     gStyle->SetOptStat(0); // <- das hier macht dies box rechts oben weg
-    cPairEffElePosMPt->SetLogz();
+    // cPairEffElePosMPt->SetLogz();
     // cPairEffElePosMPt->SetLogy();
     cPairEffElePosMPt->SetTopMargin(0.03);
     cPairEffElePosMPt->SetRightMargin(0.13);
@@ -3101,9 +2477,9 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     mPtPairEffElePos->GetXaxis()->SetTitle("m_{ee} (GeV/#it{c}^{2})");
     mPtPairEffElePos->GetZaxis()->SetTitle("pair efficiency");
     mPtPairEffElePos->GetZaxis()->RotateTitle(kTRUE);
-    mPtPairEffElePos->GetYaxis()->SetRangeUser(0.,4.);
-    // mPtPairEffElePos->GetXaxis()->SetRangeUser(0.0,0.7);
-    // mPtPairEffElePos->GetYaxis()->SetRangeUser(0.0,0.7);
+    // mPtPairEffElePos->GetYaxis()->SetRangeUser(0.,4.);
+    mPtPairEffElePos->GetXaxis()->SetRangeUser(0.0,0.7);
+    mPtPairEffElePos->GetYaxis()->SetRangeUser(0.0,0.7);
     // mPtPairEffElePos->GetZaxis()->SetRangeUser(0,1.0);
     mPtPairEffElePos->Draw("Colz");
     legendInfoPairEff->Draw("same");
@@ -3126,36 +2502,18 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   ptRecTrackBeforeSmearing_rebin->Draw("pe1");
   ptRecTrackAfterSmearing_rebin->Draw("pe1 same");
   ptRecTrackAfterKineCuts_rebin->Draw("pe1 same");
-  // ptRecTrackEtaCut_10->Draw("pe1 same");
-  // ptRecTrackEtaCut_9->Draw("pe1 same");
-  // ptRecTrackEtaCut_8->Draw("pe1 same");
-  // ptRecTrackEtaCut_7->Draw("pe1 same");
-  // ptRecTrackEtaCut_6->Draw("pe1 same");
-  // ptRecTrackEtaCut_5->Draw("pe1 same");
-  // ptRecTrackEtaCut_4->Draw("pe1 same");
-  // ptRecTrackEtaCut_3->Draw("pe1 same");
-  // ptRecTrackEtaCut_2->Draw("pe1 same");
-  // ptRecTrackEtaCut_1->Draw("pe1 same");
+
   ptRecTrackElePos_rebin->Draw("pe1 same");
   legSmearLabel->Draw("same");
   cBeforeAfterSmearing->cd(2);
-  etaRecTrackBeforeSmearing->GetXaxis()->SetRangeUser(-2.0,2.0);
+  etaRecTrackBeforeSmearing->GetXaxis()->SetRangeUser(-4.5,4.5);
   etaRecTrackBeforeSmearing->SetMinimum(0.);
   etaRecTrackBeforeSmearing->SetMaximum(1.1*std::max({etaRecTrackBeforeSmearing->GetMaximum(),etaRecTrackAfterSmearing->GetMaximum(),etaRecTrackElePos->GetMaximum()}));
   etaRecTrackBeforeSmearing->Draw("axis");
   etaRecTrackBeforeSmearing->Draw("pe1 same");
   etaRecTrackAfterSmearing->Draw("pe1 same");
   etaRecTrackAfterKineCuts->Draw("pe1 same");
-  // etaRecTrackEtaCut_10->Draw("pe1 same");
-  // etaRecTrackEtaCut_8->Draw("pe1 same");
-  // etaRecTrackEtaCut_9->Draw("pe1 same");
-  // etaRecTrackEtaCut_7->Draw("pe1 same");
-  // etaRecTrackEtaCut_6->Draw("pe1 same");
-  // etaRecTrackEtaCut_5->Draw("pe1 same");
-  // etaRecTrackEtaCut_4->Draw("pe1 same");
-  // etaRecTrackEtaCut_3->Draw("pe1 same");
-  // etaRecTrackEtaCut_2->Draw("pe1 same");
-  // etaRecTrackEtaCut_1->Draw("pe1 same");
+
   etaRecTrackElePos->Draw("pe1 same");
   cBeforeAfterSmearing->cd(3);
   phiRecTrackBeforeSmearing->SetMinimum(0.);
@@ -3164,16 +2522,7 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   phiRecTrackBeforeSmearing->Draw("pe1 same");
   phiRecTrackAfterSmearing->Draw("pe1 same");
   phiRecTrackAfterKineCuts->Draw("pe1 same");
-  // phiRecTrackEtaCut_10->Draw("pe1 same");
-  // phiRecTrackEtaCut_9->Draw("pe1 same");
-  // phiRecTrackEtaCut_8->Draw("pe1 same");
-  // phiRecTrackEtaCut_7->Draw("pe1 same");
-  // phiRecTrackEtaCut_6->Draw("pe1 same");
-  // phiRecTrackEtaCut_5->Draw("pe1 same");
-  // phiRecTrackEtaCut_4->Draw("pe1 same");
-  // phiRecTrackEtaCut_3->Draw("pe1 same");
-  // phiRecTrackEtaCut_2->Draw("pe1 same");
-  // phiRecTrackEtaCut_1->Draw("pe1 same");
+
   phiRecTrackElePos->Draw("pe1 same");
   cBeforeAfterSmearing->SaveAs("./plots/RecPtEtaPhiBeforeAfterSmearing.png");
 
@@ -3250,48 +2599,6 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   }
 
   if (bPlotTrackContamination) {
-    auto cPosNegContaminationPtEtaPhi = new TCanvas("cPosNegContaminationPtEtaPhi","cPosNegContaminationPtEtaPhi",1350,600);
-    cPosNegContaminationPtEtaPhi->Divide(3,1);
-    for (size_t i = 1; i < 4; i++) {
-      cPosNegContaminationPtEtaPhi->cd(i)->SetTopMargin(0.03);
-      cPosNegContaminationPtEtaPhi->cd(i)->SetRightMargin(0.03);
-    }
-    cPosNegContaminationPtEtaPhi->cd(1);
-    hPureContaminationRecPtNeg->GetYaxis()->SetTitle("contamination");
-    hPureContaminationRecPtNeg->GetXaxis()->SetTitle("#it{p}_{T} (GeV/#it{c})");
-    hPureContaminationRecPtNeg->GetXaxis()->SetRangeUser(0.0,4.0);
-    hPureContaminationRecPtNeg->SetMaximum(1.1);
-    // hPureContaminationRecPtNeg->SetMaximum(1.1*std::max({hPureContaminationRecPtNeg->GetMaximum(),hPureContaminationRecPtPos->GetMaximum()}));
-    hPureContaminationRecPtNeg->SetMinimum(0.);
-    // hPurityRecPtNeg->Draw("hist p e1");
-    // hPurityRecPtPos->Draw("same hist p e1");
-    hPureContaminationRecPtNeg->Draw("hist p e1");
-    hPureContaminationRecPtPos->Draw("same hist p e1");
-    legContamination->Draw("same");
-    cPosNegContaminationPtEtaPhi->cd(2);
-    hPureContaminationRecEtaNeg->GetYaxis()->SetTitle("contamination");
-    hPureContaminationRecEtaNeg->GetXaxis()->SetTitle("#eta");
-    hPureContaminationRecEtaNeg->GetXaxis()->SetRangeUser(-2.0,2.0);
-    hPureContaminationRecEtaNeg->SetMaximum(0.1);
-    // hPureContaminationRecEtaNeg->SetMaximum(1.1*std::max({hPureContaminationRecEtaNeg->GetMaximum(),hPureContaminationRecEtaPos->GetMaximum()}));
-    hPureContaminationRecEtaNeg->SetMinimum(0.);
-    // hPurityRecEtaNeg->Draw("hist p e1");
-    // hPurityRecEtaPos->Draw("same hist p e1");
-    hPureContaminationRecEtaNeg->Draw("hist p e1");
-    hPureContaminationRecEtaPos->Draw("same hist p e1");
-    cPosNegContaminationPtEtaPhi->cd(3);
-    hPureContaminationRecPhiNeg->GetYaxis()->SetTitle("contamination");
-    hPureContaminationRecPhiNeg->GetXaxis()->SetTitle("#varphi (rad)");
-    hPureContaminationRecPhiNeg->SetMaximum(0.1);
-    // hPureContaminationRecPhiNeg->SetMaximum(1.1*std::max({hPureContaminationRecPhiNeg->GetMaximum(),hPureContaminationRecPhiPos->GetMaximum()}));
-    hPureContaminationRecPhiNeg->SetMinimum(0.);
-    hPureContaminationRecPhiNeg->GetXaxis()->SetRangeUser(-7.0,7.0);
-    // hPurityRecPhiNeg->Draw("hist p e1");
-    // hPurityRecPhiPos->Draw("same hist p e1");
-    hPureContaminationRecPhiNeg->Draw("hist p e1");
-    hPureContaminationRecPhiPos->Draw("same hist p e1");
-    cPosNegContaminationPtEtaPhi->SaveAs("./plots/PID_PosNeg_Contamiantion.png");
-
 
     auto cContaminationPtEtaPhi = new TCanvas("cContaminationPtEtaPhi","cContaminationPtEtaPhi",1350,600);
     cContaminationPtEtaPhi->Divide(3,1);
@@ -3307,8 +2614,6 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     hMuonContaminationRecPt->SetMinimum(0.);
     hMuonContaminationRecPt->Draw("hist p e1");
     hPionContaminationRecPt->Draw("same hist p e1");
-    hKaonContaminationRecPt->Draw("same hist p e1");
-    hProtonContaminationRecPt->Draw("same hist p e1");
     hTotalPureContaminationRecPt->Draw("same hist p e1");
     legPIDContamination->Draw("same");
     cContaminationPtEtaPhi->cd(2);
@@ -3319,8 +2624,6 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     hMuonContaminationRecEta->SetMinimum(0.);
     hMuonContaminationRecEta->Draw("hist p e1");
     hPionContaminationRecEta->Draw("same hist p e1");
-    hKaonContaminationRecEta->Draw("same hist p e1");
-    hProtonContaminationRecEta->Draw("same hist p e1");
     hTotalPureContaminationRecEta->Draw("same hist p e1");
     cContaminationPtEtaPhi->cd(3);
     hMuonContaminationRecPhi->GetYaxis()->SetTitle("contamination");
@@ -3330,8 +2633,6 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
     hMuonContaminationRecPhi->GetXaxis()->SetRangeUser(-7.0,7.0);
     hMuonContaminationRecPhi->Draw("hist p e1");
     hPionContaminationRecPhi->Draw("same hist p e1");
-    hKaonContaminationRecPhi->Draw("same hist p e1");
-    hProtonContaminationRecPhi->Draw("same hist p e1");
     hTotalPureContaminationRecPhi->Draw("same hist p e1");
     cContaminationPtEtaPhi->SaveAs("./plots/PID_Contamiantion.png");
 
@@ -3375,9 +2676,9 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   hPionRejectionFactorPt->GetYaxis()->SetTitle("rejection factor");
   hPionRejectionFactorPt->GetXaxis()->SetTitle("#it{p}_{T} (GeV/#it{c})");
   // hPionRejectionFactorPt->GetXaxis()->SetRangeUser(0.0,4.0);
-  // hPionRejectionFactorPt->SetMaximum(10*std::max({hMuonRejectionFactorPt->GetMaximum(),hPionRejectionFactorPt->GetMaximum(),hKaonRejectionFactorPt->GetMaximum(),hProtonRejectionFactorPt->GetMaximum()/*,hTotalRejectionFactorPt->GetMaximum()*/}));
+  // hPionRejectionFactorPt->SetMaximum(10*std::max({hMuonRejectionFactorPt->GetMaximum(),hPionRejectionFactorPt->GetMaximum()/*,hTotalRejectionFactorPt->GetMaximum()*/}));
   // hPionRejectionFactorPt->SetMaximum(1.1);
-  // hPionRejectionFactorPt->SetMinimum(0.1*std::min({hMuonRejectionFactorPt->GetMinimum(),hPionRejectionFactorPt->GetMinimum(),hKaonRejectionFactorPt->GetMinimum(),hProtonRejectionFactorPt->GetMinimum()/*,hTotalRejectionFactorPt->GetMaximum()*/}));
+  // hPionRejectionFactorPt->SetMinimum(0.1*std::min({hMuonRejectionFactorPt->GetMinimum(),hPionRejectionFactorPt->GetMinimum()/*,hTotalRejectionFactorPt->GetMaximum()*/}));
   // hPionRejectionFactorPt->SetMaximum(100000000000);
   hPionRejectionFactorPt->SetMaximum(100000000);
   hPionRejectionFactorPt->SetMinimum(0.1);
@@ -3386,8 +2687,8 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   hMuonRejectionFactorPt->SetMinimum(0.1);
   hPionRejectionFactorPt->Draw("hist p e1");
   hMuonRejectionFactorPt->Draw("same hist p e1");
-  hKaonRejectionFactorPt->Draw("same hist p e1");
-  hProtonRejectionFactorPt->Draw("same hist p e1");
+  // hKaonRejectionFactorPt->Draw("same hist p e1");
+  // hProtonRejectionFactorPt->Draw("same hist p e1");
   // hTotalRejectionFactorPt->Draw("same hist p e1");
   legRejFactor->Draw("same");
   legendInfo->Draw("same");
@@ -3395,8 +2696,8 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   // textPIDScenario_conta->Draw("same");
   cRejectionFactorPt->SetTicks();
   cRejectionFactorPt->SaveAs("./plots/PID_Pt_RejectionFactor.png");
-  hPionRejectionFactorPt->SetMinimum(1000);
-  hPionRejectionFactorPt->SetMaximum(100000000);
+  // hPionRejectionFactorPt->SetMinimum(1000);
+  // hPionRejectionFactorPt->SetMaximum(100000000);
   // hPionRejectionFactorPt->GetXaxis()->SetRangeUser(0.0,3.5);
   hPionRejectionFactorPt->Draw("hist p e1");
   TLine* line = new TLine(0.,100000.,4.,100000.);
@@ -3664,11 +2965,11 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
       // legPair->Draw("same");
       // cPtee_primCCBB->SaveAs("./plots/Ptee_primCCBB.png");
 
-      auto cprojMeePteeDCA = new TCanvas("cprojMeePteeDCA","cprojMeePteeDCA",1800,800);
-      cprojMeePteeDCA->Divide(3,1);
+      auto cprojMeePtee = new TCanvas("cprojMeePtee","cprojMeePtee",1800,800);
+      cprojMeePtee->Divide(2,1);
       for (size_t i = 1; i < 4; i++) {
-        cprojMeePteeDCA->cd(i)->SetTopMargin(0.03);
-        cprojMeePteeDCA->cd(i)->SetRightMargin(0.03);
+        cprojMeePtee->cd(i)->SetTopMargin(0.03);
+        cprojMeePtee->cd(i)->SetRightMargin(0.03);
         gStyle->SetOptStat(0); // <- das hier macht dies box rechts oben weg
       }
       Double_t lx_low; Double_t lx_high; Double_t ly_low; Double_t ly_high;
@@ -3707,8 +3008,8 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
       legendPtee->SetFillColorAlpha(0, 0.0);
       legendInfo->SetTextSize(0.035);
       legendPtee->SetTextSize(0.035);
-      cprojMeePteeDCA->cd(1);
-      cprojMeePteeDCA->cd(1)->SetLogy();
+      cprojMeePtee->cd(1);
+      cprojMeePtee->cd(1)->SetLogy();
       proj_recULS_Mee->GetYaxis()->SetTitle("Yield");
       proj_recULS_Mee->GetXaxis()->SetTitle("m_{ee} (GeV/#it{c}^{2})");
       // proj_recULS_Mee->RebinX(2);
@@ -3717,8 +3018,8 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
       proj_recULS_Mee->Draw("hist p e1");
       proj_recLS_Mee->Draw("same hist p e1");
       legendInfo->Draw("same");
-      cprojMeePteeDCA->cd(2);
-      cprojMeePteeDCA->cd(2)->SetLogy();
+      cprojMeePtee->cd(2);
+      cprojMeePtee->cd(2)->SetLogy();
       proj_recULS_Ptee->GetYaxis()->SetTitle("Yield");
       proj_recULS_Ptee->GetXaxis()->SetTitle("p_{T,ee} (GeV/#it{c})");
       // proj_recULS_Ptee->RebinX(2);
@@ -3727,14 +3028,7 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
       proj_recLS_Ptee->Draw("same hist p e1");
       legendPtee->Draw("same");
 
-      cprojMeePteeDCA->cd(3);
-      cprojMeePteeDCA->cd(3)->SetLogy();
-      proj_recULS_DCA->GetYaxis()->SetTitle("Yield");
-      proj_recULS_DCA->GetXaxis()->SetTitle("DCA_{ee} (#sigma)");
-      proj_recULS_DCA->GetXaxis()->SetRangeUser(0.0,20.0);
-      proj_recULS_DCA->Draw("hist p e1");
-      proj_recLS_DCA->Draw("same hist p e1");
-      cprojMeePteeDCA->SaveAs(Form("./plots/projMeePteeDCAee_sce%i.png",ith_PIDscenario));
+      cprojMeePtee->SaveAs(Form("./plots/projMeePteeee_sce%i.png",ith_PIDscenario));
 
       // auto cMeePteeTH2 = new TCanvas("cMeePteeTH2","cMeePteeTH2",800,800);
       // cMeePteeTH2->SetTopMargin(0.03);
@@ -3874,46 +3168,47 @@ legSigLFtoee->AddEntry(hCocktailPhitoee,"cocktail #phi #rightarrow ee","l");
   }
 
 
-  // TString nameEffRootFile = inputFile.Data();
-  // TString endDirName = "23.8.21_ptcut0.3_TOFRICH_Run2TBField";
-  // if (inputFile.Contains("data")) nameEffRootFile.ReplaceAll("./data/prod/anaEEstudy.", "");
-  // // if (inputFile.Contains("B2_100k")) nameEffRootFile.ReplaceAll(Form("../grid/output/B2_100k_502TeV_%s/anaEEstudy.",endDirName.Data()), "");
-  // // if (inputFile.Contains("B5_100k")) nameEffRootFile.ReplaceAll(Form("../grid/output/B5_100k_502TeV_%s/anaEEstudy.",endDirName.Data()), "");
-  // // if (inputFile.Contains("B2_2M_502TeV")) nameEffRootFile.ReplaceAll(Form("../grid/output/B2_2M_502TeV_%s/anaEEstudy.",endDirName.Data()), "");
-  // // if (inputFile.Contains("B5_2M_502TeV")) nameEffRootFile.ReplaceAll(Form("../grid/output/B5_2M_502TeV_%s/anaEEstudy.",endDirName.Data()), "");
-  // // if (inputFile.Contains("B=0.5_2M_502TeV")) nameEffRootFile.ReplaceAll("/data/feisenhut/DelphesO2/ALICE3-LoI-LMee/efficiency/data/prod/anaEEstudy.", "");
-  // // if (inputFile.Contains("B5_100k_502TeV")) nameEffRootFile.ReplaceAll(Form("/data/feisenhut/DelphesO2/ALICE3-LoI-LMee/grid/output/B5_100k_502TeV_%s/anaEEstudy.",endDirName.Data()), "");
+  // Generate further root files with new plots
+
+  TString nameEffRootFile = inputFile.Data();
+  TString endDirName = "12.9.21_ptcut0.2_0.8eta_6PFstudies_woPF_oTOFRICH_iTOFpfacc_diffOpAngleMassCuts";
+  // TString endDirName = "12.8.21_TOFRICH_0.2ptcut_WeightsLFHF";
+  if (inputFile.Contains("./data")) nameEffRootFile.ReplaceAll("./data/prod/anaEEstudy.", "");
+  if (inputFile.Contains("../grid/second_job")) nameEffRootFile.ReplaceAll("../grid/second_job/data/prod/anaEEstudy.", "");
+  // if (inputFile.Contains("B2_100k")) nameEffRootFile.ReplaceAll(Form("../grid/output/B2_100k_502TeV_%s/anaEEstudy.",endDirName.Data()), "");
+  // if (inputFile.Contains("B5_100k")) nameEffRootFile.ReplaceAll(Form("../grid/output/B5_100k_502TeV_%s/anaEEstudy.",endDirName.Data()), "");
+  // if (inputFile.Contains("B2_2M_502TeV")) nameEffRootFile.ReplaceAll(Form("../grid/output/B2_2M_502TeV_%s/anaEEstudy.",endDirName.Data()), "");
+  // if (inputFile.Contains("B5_2M_502TeV")) nameEffRootFile.ReplaceAll(Form("../grid/output/B5_2M_502TeV_%s/anaEEstudy.",endDirName.Data()), "");
+  // if (inputFile.Contains("B=0.5_2M_502TeV")) nameEffRootFile.ReplaceAll("/data/feisenhut/DelphesO2/ALICE3-LoI-LMee/efficiency/data/prod/anaEEstudy.", "");
+  if (inputFile.Contains("B5_100k_502TeV")) nameEffRootFile.ReplaceAll(Form("/data/feisenhut/DelphesO2/ALICE3-LoI-LMee/grid/output/B5_100k_502TeV_%s/anaEEstudy.",endDirName.Data()), "");
   // if (inputFile.Contains("B20_100k_502TeV")) nameEffRootFile.ReplaceAll(Form("/data/feisenhut/DelphesO2/ALICE3-LoI-LMee/grid/output/B20_100k_502TeV_%s/anaEEstudy.",endDirName.Data()), "");
-  // nameEffRootFile.ReplaceAll(".root", "");
-  // TFile *fOut = TFile::Open(Form("./data/TrackEff_%s_PIDscenario%i.root",nameEffRootFile.Data(),ith_PIDscenario),"RECREATE");
-  //
-  // if (bPlotEfficiency) {
-  //   ptEffEle->SetTitle("eff_singleElectrons_Rec/GenSmeared");
-  //   ptEffPos->SetTitle("eff_singlePositrons_Rec/GenSmeared");
-  //   ptEffEle->GetXaxis()->SetRangeUser(0.0,10.0);
-  //   ptEffPos->GetXaxis()->SetRangeUser(0.0,10.0);
-  //   ptEffEle->Write();
-  //   ptEffPos->Write();
-  //   ptEffElePosGen->SetTitle("eff_Track_Rec/Generated");
-  //   ptEffElePosGenSmeared->SetTitle("eff_Track_Rec/GeneratedSmeared");
-  //   ptEffElePosGen->GetXaxis()->SetRangeUser(0.0,10.0);
-  //   ptEffElePosGenSmeared->GetXaxis()->SetRangeUser(0.0,10.0);
-  //   ptEffElePosGen->Write();
-  //   ptEffElePosGenSmeared->Write();
-  //
-  //   ptEtaEffElePos->SetTitle("eff_pteta_2D");
-  //   ptEtaEffElePos->GetXaxis()->SetRangeUser(0.0,4.0);
-  //   ptEtaEffElePos->GetYaxis()->SetRangeUser(-1.2,1.2);
-  //   ptEtaEffElePos->Write();
-  //
-  // }
-  //
-  // if (bPlotTrackContamination) {
-  //   hTotalPureContaminationRecPt->SetTitle("Total Contamination");
-  //   hTotalPureContaminationRecPt->GetXaxis()->SetRangeUser(0.0,4.0);
-  //   hTotalPureContaminationRecPt->Write();
-  // }
-  // fOut->Close();
+  nameEffRootFile.ReplaceAll(".root", "");
+  TFile *fOut = TFile::Open(Form("./data/efficiencies/TrackEff_%s_PIDscenario%i.root",nameEffRootFile.Data(),ith_PIDscenario),"RECREATE");
 
+  if (bPlotEfficiency) {
+    ptEffElePosGen->SetTitle("eff_Track_Rec/Generated");
+    ptEffElePosGenSmeared->SetTitle("eff_Track_Rec/GeneratedSmeared");
+    ptEffElePosGen->GetXaxis()->SetRangeUser(0.0,10.0);
+    ptEffElePosGenSmeared->GetXaxis()->SetRangeUser(0.0,10.0);
+    ptEffElePosGen->Write();
+    ptEffElePosGenSmeared->Write();
+    ptEffElePosGenSmeared->SetTitle("eff_HF_Track_Rec/Generated");
+    // ptEffElePos_LF_afterPF->Write();
+    ptEffElePos_HF_afterPF->Write();
 
+    ptEtaEffElePos->SetTitle("eff_pteta_2D");
+    ptEtaEffElePos->GetXaxis()->SetRangeUser(0.0,4.0);
+    ptEtaEffElePos->GetYaxis()->SetRangeUser(-1.2,1.2);
+    ptEtaEffElePos->Write();
+
+  }
+
+  if (bPlotTrackContamination) {
+    hTotalPureContaminationRecPt->SetTitle("Total Contamination");
+    hTotalPureContaminationRecPt->GetXaxis()->SetRangeUser(0.0,4.0);
+    hTotalPureContaminationRecPt->Write();
+  }
+  fOut->Close();
+
+}
 }

--- a/grid/generateDelphes_FE.sh
+++ b/grid/generateDelphes_FE.sh
@@ -13,7 +13,7 @@ runDelphes() {
 NEVENTS=$1     # number of events in a run
 
 # SYSTEM="pp_inel"   # Select the system. This will copy the coresponding pythia configuration. Make sure it exists in the pythia directory.
-SYSTEM=$2   # Select the system. This will copy the coresponding pythia configuration. Make sure it exists in the pythia directory.
+SYSTEM=$2   # Select the system. This will copy the corresponding pythia configuration. Make sure it exists in the pythia directory.
 
 RADIUS=100     # radius tracks have to reach for reco
 # RADIUS=10     # radius tracks have to reach for reco
@@ -24,19 +24,20 @@ SIGMAT=0.020   # time resolution [ns]
 SIGMA0=0.200         # vertex time spread [ns]
 TAILLX=1.0     # tail on left    [q]
 TAILRX=1.3     # tail on right   [q]
-# TOFRAD=19.     # TOF radius      [cm]
-# TOFLEN=38.     # TOF half length [cm]
+# TOFRAD=20.     # TOF radius      [cm]
+# TOFLEN=56.     # TOF half length [cm]
 TOFRAD=100.     # TOF radius      [cm]
-TOFLEN=200.     # TOF half length [cm]
-TOFETA=1.443   # TOF max pseudorapidity
+TOFLEN=280.     # TOF half length [cm]
+# TOFETA=1.443   # TOF max pseudorapidity
 RICHRAD=100.      # RICH radius      [cm]
-RICHLEN=200.      # RICH half length [cm]
+RICHLEN=280.      # RICH half length [cm]
+BARRELETA=4.      # Barrel max pseudorapidity
 
 ENERGY=$4
 
 ### calculate max eta from geometry
-TOFETA=`awk -v a=$TOFRAD -v b=$TOFLEN 'BEGIN {th=atan2(a,b)*0.5; sth=sin(th); cth=cos(th); print -log(sth/cth)}'`
-echo "maxEta = $TOFETA"
+# TOFETA=`awk -v a=$TOFRAD -v b=$TOFLEN 'BEGIN {th=atan2(a,b)*0.5; sth=sin(th); cth=cos(th); print -log(sth/cth)}'`
+echo "maxEta = $BARRELETA"
 
 #how many events are generated
 echo " --- generating events:"
@@ -60,13 +61,17 @@ echo "Random:setSeed on" >> pythia8.cfg
 #use process id as seed maybe add time?
 echo "Random:seed = $$" >> pythia8.cfg
 
-cp lutCovm.el.werner.rmin${RADIUS}.${BFIELD}kG.dat lutCovm.el.dat
-cp lutCovm.mu.werner.rmin${RADIUS}.${BFIELD}kG.dat lutCovm.mu.dat
-cp lutCovm.pi.werner.rmin${RADIUS}.${BFIELD}kG.dat lutCovm.pi.dat
-cp lutCovm.ka.werner.rmin${RADIUS}.${BFIELD}kG.dat lutCovm.ka.dat
-cp lutCovm.pr.werner.rmin${RADIUS}.${BFIELD}kG.dat lutCovm.pr.dat
+# cp lutCovm.el.werner.rmin${RADIUS}.${BFIELD}kG.dat lutCovm.el.dat
+# cp lutCovm.mu.werner.rmin${RADIUS}.${BFIELD}kG.dat lutCovm.mu.dat
+# cp lutCovm.pi.werner.rmin${RADIUS}.${BFIELD}kG.dat lutCovm.pi.dat
+# cp lutCovm.ka.werner.rmin${RADIUS}.${BFIELD}kG.dat lutCovm.ka.dat
+# cp lutCovm.pr.werner.rmin${RADIUS}.${BFIELD}kG.dat lutCovm.pr.dat
 
-
+cp lutCovm.el.${BFIELD}kG.rmin${RADIUS}.geometry_v1.dat lutCovm.el.dat
+cp lutCovm.mu.${BFIELD}kG.rmin${RADIUS}.geometry_v1.dat lutCovm.mu.dat
+cp lutCovm.pi.${BFIELD}kG.rmin${RADIUS}.geometry_v1.dat lutCovm.pi.dat
+cp lutCovm.ka.${BFIELD}kG.rmin${RADIUS}.geometry_v1.dat lutCovm.ka.dat
+cp lutCovm.pr.${BFIELD}kG.rmin${RADIUS}.geometry_v1.dat lutCovm.pr.dat
 
 # Set B fild in propagation card and analysis macro
 sed -i -e "s/set barrel_Bz .*$/set barrel_Bz ${BFIELD}e\-1/" propagate.tcl
@@ -79,7 +84,7 @@ sed -i -e "s/double tof_radius = .*$/double tof_radius = ${TOFRAD}\;/" anaEEstud
 sed -i -e "s/set barrel_HalfLength .*$/set barrel_HalfLength ${TOFLEN}e\-2/" propagate.tcl
 sed -i -e "s/double tof_length = .*$/double tof_length = ${TOFLEN}\;/" anaEEstudy.cxx
 ### set TOF acceptance
-sed -i -e "s/set barrel_Acceptance .*$/set barrel_Acceptance \{ 0.0 + 1.0 * fabs(eta) < ${TOFETA} \}/" propagate.tcl
+sed -i -e "s/set barrel_Acceptance .*$/set barrel_Acceptance \{ 0.0 + 1.0 * fabs(eta) < ${BARRELETA} \}/" propagate.tcl
 ### set TOF time resolution and tails
 sed -i -e "s/set barrel_TimeResolution .*$/set barrel_TimeResolution ${SIGMAT}e\-9/" propagate.tcl
 sed -i -e "s/set barrel_TailRight .*$/set barrel_TailRight ${TAILRX}/" propagate.tcl
@@ -115,7 +120,7 @@ echo " SIGMAT      = ${SIGMAT}      # time resolution [ns]"
 echo " SIGMA0      = ${SIGMA0}      # vertex time spread [ns]"
 echo " BARRELRAD   = ${TOFRAD}       # barrel radius      [cm] (right now equal to TOF)"
 echo " BARRELLEN   = ${TOFLEN}       # barrel half length [cm] (right now equal to TOF)"
-echo " BARRELETA   = ${TOFETA}    # barrel max pseudorapidity"
+echo " BARRELETA   = ${BARRELETA}    # barrel max pseudorapidity"
 echo " TAILLX      = ${TAILLX}        # tail on left    [q]"
 echo " TAILRX      = ${TAILRX}        # tail on right   [q]"
 echo " TOFRAD      = ${TOFRAD}       # TOF radius      [cm]"

--- a/grid/r5lmee_FE.jdl
+++ b/grid/r5lmee_FE.jdl
@@ -5,7 +5,7 @@ Validationcommand = "/alice/cern.ch/user/f/feisenhu/grid/Delphes/validation_FE.s
 #submit in following order: Nevents System BField OutputDir
 Arguments = "$1 $2 $3 $4 $5";
 Packages = {
-	"VO_ALICE@DelphesO2::v20210427-2"
+	"VO_ALICE@DelphesO2::v20210825-1"
 };
 
 JDLVariables = {
@@ -25,16 +25,21 @@ Workdirectorysize = {
 	"12000MB"
 };
 
-Split = "production:1-10";
+Split = "production:1-100";
 SplitArguments = "";
 
 
 InputFile = {
-  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.werner.rmin100.$3kG//lutCovm.el.werner.rmin100.$3kG.dat",
-  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.werner.rmin100.$3kG//lutCovm.mu.werner.rmin100.$3kG.dat",
-  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.werner.rmin100.$3kG//lutCovm.pi.werner.rmin100.$3kG.dat",
-  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.werner.rmin100.$3kG//lutCovm.ka.werner.rmin100.$3kG.dat",
-  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.werner.rmin100.$3kG//lutCovm.pr.werner.rmin100.$3kG.dat",
+#  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.werner.rmin100.$3kG//lutCovm.el.werner.rmin100.$3kG.dat",
+#  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.werner.rmin100.$3kG//lutCovm.mu.werner.rmin100.$3kG.dat",
+#  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.werner.rmin100.$3kG//lutCovm.pi.werner.rmin100.$3kG.dat",
+#  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.werner.rmin100.$3kG//lutCovm.ka.werner.rmin100.$3kG.dat",
+#  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.werner.rmin100.$3kG//lutCovm.pr.werner.rmin100.$3kG.dat",
+  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.geometry_v1.rmin100.$3kG//lutCovm.el.$3kG.rmin100.geometry_v1.dat",
+  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.geometry_v1.rmin100.$3kG//lutCovm.mu.$3kG.rmin100.geometry_v1.dat",
+  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.geometry_v1.rmin100.$3kG//lutCovm.pi.$3kG.rmin100.geometry_v1.dat",
+  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.geometry_v1.rmin100.$3kG//lutCovm.ka.$3kG.rmin100.geometry_v1.dat",
+  "LF:/alice/cern.ch/user/f/feisenhu/grid/LUTs/lutCovm.geometry_v1.rmin100.$3kG//lutCovm.pr.$3kG.rmin100.geometry_v1.dat",
   "LF:/alice/cern.ch/user/f/feisenhu/grid/corrWeights//hfe_weights.root",
   "LF:/alice/cern.ch/user/f/feisenhu/grid/corrWeights//lfe_weights.root",
 	"LF:/alice/cern.ch/user/f/feisenhu/grid/resolutionfiles//resolution_test_$3kG.root",


### PR DESCRIPTION
Major chnages to anaEEstudy and anaPlots scripts.

anaEEstudy:
- implementing Prefilter, using new vectors for prefilter pairing, using opening angle and mass as par cuts in prefilter, implement pt cut for prefilter
- removed NSigma Plots
- new binning of histograms to improve memory usage in jobs
- changed centrality selection currently 30-50%
- make doiTOFPID usable to oTOF, rename to doTOFPID
- added options to study pseudorapidity acceptance and prefilter studies
- new selection of detector PID between Preshower and TOF+RICH
- reduced number of histograms / got rid of some only e+ or e- plots
- clean up


anaPlots:
- generating new root files to compare different scenarios of prefilter studies and pseudorapidity studies
- adapt to new binnings
- removed PID NSigma plots
- removed dead code
- option to apply DCA cut
- removed some plots only showing electrons or positrons


generateEffieciencies:
- change the eta coverage of the Barrel as well as of the oTOF and RICH detectors
- Radius =100,  Length=200 -> 280 in order to cover a pseudorapidity of 1.75
